### PR TITLE
Added DropletStatus enum

### DIFF
--- a/src/main/java/com/myjeeva/digitalocean/DropletStatus.java
+++ b/src/main/java/com/myjeeva/digitalocean/DropletStatus.java
@@ -1,0 +1,37 @@
+package com.myjeeva.digitalocean;
+
+/**
+ * Describes possible droplet states.
+ */
+public enum DropletStatus {
+
+    New("new"),
+    Active("active"),
+    Off("off");
+
+    private String value;
+
+    private DropletStatus(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    public static DropletStatus fromValue(String value) {
+        if (value == null || "".equals(value)) {
+            throw new IllegalArgumentException("Value cannot be null or empty!");
+
+        } else if ("new".equals(value)) {
+            return DropletStatus.New;
+        } else if ("active".equals(value)) {
+            return DropletStatus.Active;
+        } else if ("off".equals(value)) {
+            return DropletStatus.Off;
+        } else {
+            throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+        }
+    }
+}

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Droplet.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Droplet.java
@@ -23,9 +23,10 @@
  */
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
 import com.google.gson.annotations.SerializedName;
+import com.myjeeva.digitalocean.DropletStatus;
+
+import java.util.List;
 
 /**
  * Represents Droplet attributes of DigitalOcean
@@ -280,4 +281,36 @@ public class Droplet {
 		this.eventId = eventId;
 	}
 
+    /**
+     * @return true if droplet is active
+     */
+    public boolean isActive() {
+        try {
+            return DropletStatus.fromValue(status) == DropletStatus.Active;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return true if droplet is new, meaning it's booting up
+     */
+    public boolean isNew() {
+        try {
+            return DropletStatus.fromValue(status) == DropletStatus.New;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return true if droplet is turned off
+     */
+    public boolean isOff() {
+        try {
+            return DropletStatus.fromValue(status) == DropletStatus.Off;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
 }

--- a/src/test/java/com/myjeeva/digitalocean/DigitalOceanTest.java
+++ b/src/test/java/com/myjeeva/digitalocean/DigitalOceanTest.java
@@ -23,15 +23,6 @@
  */
 package com.myjeeva.digitalocean;
 
-import java.util.List;
-
-import junit.framework.TestCase;
-
-import org.junit.Ignore;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.myjeeva.digitalocean.exception.AccessDeniedException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.exception.ResourceNotFoundException;
@@ -43,6 +34,13 @@ import com.myjeeva.digitalocean.pojo.DropletImage;
 import com.myjeeva.digitalocean.pojo.DropletSize;
 import com.myjeeva.digitalocean.pojo.Region;
 import com.myjeeva.digitalocean.pojo.Response;
+import junit.framework.TestCase;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * <p>
@@ -494,6 +492,24 @@ public class DigitalOceanTest extends TestCase {
 		LOG.info("Response Status: " + response.getStatus());
 		LOG.info("Response Object: " + response);
 	}
+
+    @Test
+    public void testDropletStates() {
+
+        Droplet droplet = new Droplet();
+        droplet.setStatus(DropletStatus.New.toString());
+        assertTrue(droplet.isNew());
+        assertFalse(droplet.isActive());
+
+        droplet.setStatus(DropletStatus.Active.toString());
+        assertTrue(droplet.isActive());
+        assertFalse(droplet.isNew());
+
+        droplet.setStatus(DropletStatus.Off.toString());
+        assertTrue(droplet.isOff());
+        assertFalse(droplet.isActive());
+
+    }
 
 	private void assertAndLogResponseValue(Response response) {
 


### PR DESCRIPTION
This PR adds a `DropletStatus` enum and a couple of convenience methods to `Droplet` for consistent checks of the current status of a droplet.
