### PR TITLE
Changing ActionType of reset root password method to PASSWORD_RESET

### DIFF
--- a/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
+++ b/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
@@ -341,7 +341,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
     Object[] params = {dropletId};
     return (Action) perform(
-        new ApiRequest(ApiAction.RESET_DROPLET_PASSWORD, new DropletAction(ActionType.POWER_CYCLE),
+        new ApiRequest(ApiAction.RESET_DROPLET_PASSWORD, new DropletAction(ActionType.PASSWORD_RESET),
             params)).getData();
   }
 


### PR DESCRIPTION
The resetDropletPassword() method is sending a power_cycle request to DigitalOcean due the ActionType. I changed the type to PASSWORD_RESET. 
