### PR TITLE
add support of min_disk_size for Image

### DIFF
--- a/src/main/java/com/myjeeva/digitalocean/pojo/Image.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Image.java
@@ -32,7 +32,7 @@ import com.myjeeva.digitalocean.common.ImageType;
 /**
  * Represents Droplet Image (also public images aka Distribution) attributes of DigitalOcean
  * (distribution, snapshots or backups). Revised as per v2 API data structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Image extends RateLimitBase {
@@ -58,6 +58,9 @@ public class Image extends RateLimitBase {
 
   @SerializedName("min_size")
   private String minSize;
+
+  @SerializedName("min_disk_size")
+  private Integer minDiskSize;
 
   private ImageType type;
 
@@ -223,5 +226,19 @@ public class Image extends RateLimitBase {
    */
   public void setType(ImageType type) {
     this.type = type;
+  }
+
+  /**
+   * @return the min Disk Size
+   */
+  public Integer getMinDiskSize() {
+    return minDiskSize;
+  }
+
+  /**
+   * @param minDiskSize the minDiskSize to set
+   */
+  public void setMinDiskSize(Integer minDiskSize) {
+    this.minDiskSize = minDiskSize;
   }
 }


### PR DESCRIPTION
Hi Jeevanandam,

Here tiny change to support min_disk_size property of images. 
I think it would be also good to remove min_size property, just because there is no longer such property in DO API docs: https://developers.digitalocean.com/documentation/v2/#images

btw: Thanks for you effort, your project is really helpful.