### PR TITLE
debug the actual http requests' method and URI

### DIFF
--- a/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
+++ b/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
@@ -1384,6 +1384,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
   private String executeHttpRequest(HttpUriRequest request) throws DigitalOceanException,
       RequestUnsuccessfulException {
+    LOG.debug("HTTP Execute:: " + request.getMethod() + " " + request.getURI());
     String response = "";
     CloseableHttpResponse httpResponse = null;
     try {


### PR DESCRIPTION
There already is a debug statement for the response, however without also
logging the requests that information is only partially useful. In
particular when a higher level piece of software using the API runs into
problems it will often be easier to debug backwards from a request, which
kind of requires knowing what the request was.