### PR TITLE
add maven plugin to check code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,12 @@ Please refer to https://github.com/jeevatkm/digitalocean-api-java/graphs/contrib
 
 1. Fork it
 2. Create your feature branch - `git checkout -b my-new-feature`
-3. Implement your changes and apply [Google Java Code Formatter](https://raw.githubusercontent.com/darcyliu/google-styleguide/master/eclipse-java-google-style.xml)
-4. Commit your changes - `git commit -am 'Added feature'`
-5. Push to the branch - `git push origin my-new-feature`
-6. Create new Pull Request
+3. Implement your changes 
+4. Format your code with `./mvnw com.coveo:fmt-maven-plugin:format`
+5. Check tests passig with `./mvnw verify`
+6. Commit your changes - `git commit -am 'Added feature'`
+7. Push to the branch - `git push origin my-new-feature`
+9. Create new Pull Request
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,21 @@
 	<build>
 		<defaultGoal>install</defaultGoal>
 
+        	<plugins>
+	            <plugin>
+	                <groupId>com.coveo</groupId>
+	                <artifactId>fmt-maven-plugin</artifactId>
+	                <version>2.9</version>
+	                <executions>
+	                    <execution>
+	                        <goals>
+	                            <goal>check</goal>
+	                        </goals>
+	                    </execution>
+	                </executions>
+	            </plugin>
+	        </plugins>
+
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/src/main/java/com/myjeeva/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/myjeeva/digitalocean/DigitalOcean.java
@@ -1,27 +1,24 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean;
-
-import java.util.List;
 
 import com.myjeeva.digitalocean.common.ActionType;
 import com.myjeeva.digitalocean.exception.DigitalOceanException;
@@ -62,36 +59,31 @@ import com.myjeeva.digitalocean.pojo.Tag;
 import com.myjeeva.digitalocean.pojo.Tags;
 import com.myjeeva.digitalocean.pojo.Volume;
 import com.myjeeva.digitalocean.pojo.Volumes;
+import java.util.List;
 
 /**
- * <p>
  * <strong>DigitalOcean API client in Java</strong>
- * </p>
- * 
- * <p>
- * A simple and meaningful java methods for <a href="https://api.digitalocean.com/">DigitalOcean's
- * API</a>. All of the RESTful that you find in DigitalOcean API's Version 2 is available via simple
- * java methods.
- * </p>
- * 
- * <p>
- * <strong>Sample Code:</strong>
- * </p>
- * 
+ *
+ * <p>A simple and meaningful java methods for <a
+ * href="https://api.digitalocean.com/">DigitalOcean's API</a>. All of the RESTful that you find in
+ * DigitalOcean API's Version 2 is available via simple java methods.
+ *
+ * <p><strong>Sample Code:</strong>
+ *
  * <pre>
  * // Create a DigitalOcean client
- * DigitalOcean apiClient = new DigitalOceanClient(authToken); 
+ * DigitalOcean apiClient = new DigitalOceanClient(authToken);
  * <code>or</code>
  * DigitalOcean apiClient = new DigitalOceanClient("v2", authToken);
- * 
+ *
  * <strong>Let's invoke the appropriate method as per need</strong>
- * 
- * // Fetching all the available droplets from control panel 
+ *
+ * // Fetching all the available droplets from control panel
  * Droplets droplets = apiClient.getAvailableDroplets(pageNo);
- * 
+ *
  * // Fetching all the available kernels for droplet
- * Kernels kernels = apiClient.getAvailableKernels(dropletId, pageNo); 
- * 
+ * Kernels kernels = apiClient.getAvailableKernels(dropletId, pageNo);
+ *
  * // Create a new droplet
  * Droplet newDroplet = new Droplet();
  * newDroplet.setName("api-client-test-host");
@@ -101,22 +93,21 @@ import com.myjeeva.digitalocean.pojo.Volumes;
  * newDroplet.setEnableBackup(Boolean.TRUE);
  * newDroplet.setEnableIpv6(Boolean.TRUE);
  * newDroplet.setEnablePrivateNetworking(Boolean.TRUE);
- * Droplet droplet = apiClient.createDroplet(newDroplet); 
- * 
- * // Fetch droplet information 
+ * Droplet droplet = apiClient.createDroplet(newDroplet);
+ *
+ * // Fetch droplet information
  * Droplet droplet = apiClient.getDropletInfo(dropletId);
- * 
+ *
  * // Fetch Available Plans/Sizes supported by DigitalOcean
  * Sizes sizes = apiClient.getAvailableSizes(pageNo);
- * 
+ *
  * // Fetch Available Regions supported by DigitalOcean
  * Sizes sizes = apiClient.getAvailableRegions(pageNo);
- * 
+ *
  * and so on... simple to use and effective!
  * </pre>
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v1.0
  */
 public interface DigitalOcean {
@@ -128,30 +119,28 @@ public interface DigitalOcean {
   /**
    * Method returns all active droplets that are currently running in your account. All available
    * API information is presented for each droplet.
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Droplets}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
-   **/
+   */
   Droplets getAvailableDroplets(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method returns all available kernels for given droplet ID
-   * 
+   *
    * @param dropletId for kernel info
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Kernels}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Kernels getDropletKernels(Integer dropletId, Integer pageNo, Integer perPage)
@@ -159,15 +148,14 @@ public interface DigitalOcean {
 
   /**
    * Method returns all available snapshots for given droplet ID
-   * 
+   *
    * @param dropletId for snapshot info
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Snapshots}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Snapshots getDropletSnapshots(Integer dropletId, Integer pageNo, Integer perPage)
@@ -175,14 +163,13 @@ public interface DigitalOcean {
 
   /**
    * Method returns all available snapshots for given droplet ID
-   * 
+   *
    * @param dropletId for backup info
    * @param pageNo for pagination
    * @return {@link Backups}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Backups getDropletBackups(Integer dropletId, Integer pageNo, Integer perPage)
@@ -190,32 +177,27 @@ public interface DigitalOcean {
 
   /**
    * Method returns complete information for given droplet ID
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Droplet}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Droplet getDropletInfo(Integer dropletId)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
-   * <p>
    * Method allows you to create a new droplet. See the required parameters section below for an
    * explanation of the variables that are needed to create a new droplet.
-   * </p>
-   * <p>
-   * <strong>Note:</strong> Currently return object doesn't include 'action' information of create
-   * droplet.
-   * </p>
-   * <p>
-   * Create a instance of {@link Droplet} class and populated the droplet object appropriately.
+   *
+   * <p><strong>Note:</strong> Currently return object doesn't include 'action' information of
+   * create droplet.
+   *
+   * <p>Create a instance of {@link Droplet} class and populated the droplet object appropriately.
    * Minimum required values are -
-   * </p>
-   * 
+   *
    * <pre>
    * {
    *   "name": "example-droplet-name",
@@ -225,28 +207,24 @@ public interface DigitalOcean {
    *   "backups": false
    * }
    * </pre>
-   * 
+   *
    * @param droplet the instance of the droplet class
    * @return {@link Droplet}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Droplet createDroplet(Droplet droplet) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
-   * <p>
    * Method allows you to create multiple droplets simultaneously. See the required parameters
    * section below for an explanation of the variables that are needed to create multiple droplets.
-   * </p>
-   * <p>
-   * Create a instance of {@link Droplet} class and populated the droplet object appropriately.
+   *
+   * <p>Create a instance of {@link Droplet} class and populated the droplet object appropriately.
    * Particularly <strong>names</strong> attribute in the Droplet class. Minimum required values are
    * -
-   * </p>
-   * 
+   *
    * <pre>
    * {
    *   "names": [
@@ -259,13 +237,12 @@ public interface DigitalOcean {
    *   "backups": false
    * }
    * </pre>
-   * 
+   *
    * @param droplet the instance of the droplet class
    * @return {@link Droplet}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Droplets createDroplets(Droplet droplet)
@@ -273,13 +250,12 @@ public interface DigitalOcean {
 
   /**
    * Method destroys one of your droplet; this is irreversible.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Delete deleteDroplet(Integer dropletId)
@@ -287,13 +263,12 @@ public interface DigitalOcean {
 
   /**
    * Method destroys one or more of your droplet by given tag name; this is irreversible.
-   * 
+   *
    * @param tagName the associated tag name with droplet
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.9
    */
   Delete deleteDropletByTagName(String tagName)
@@ -302,14 +277,13 @@ public interface DigitalOcean {
   /**
    * For an individual droplet; Method retrieves a list of droplets that are running on the same
    * physical server (any other droplets that share the same physical hardware).
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param pageNo for pagination
    * @return {@link Droplets}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Droplets getDropletNeighbors(Integer dropletId, Integer pageNo)
@@ -318,13 +292,12 @@ public interface DigitalOcean {
   /**
    * For an entire account; Method retrieves a list of <strong>any</strong> droplets that are
    * running on the same physical server (any other droplets that share the same physical hardware).
-   * 
+   *
    * @param pageNo for pagination
    * @return {@link Neighbors}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Neighbors getAllDropletNeighbors(Integer pageNo)
@@ -332,18 +305,17 @@ public interface DigitalOcean {
 
   /**
    * To list Droplets by a tag.
-   * 
-   * The response will match that of regular droplet listing request but will be filtered to only
+   *
+   * <p>The response will match that of regular droplet listing request but will be filtered to only
    * include the tagged Droplets.
-   * 
+   *
    * @param tagName for tagName
    * @param pageNo for pagination
    * @param perPage for pagination
    * @return {@link Droplets}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.16
    */
   Droplets getAvailableDropletsByTagName(String tagName, Integer pageNo, Integer perPage)
@@ -356,13 +328,12 @@ public interface DigitalOcean {
   /**
    * Method allows you to reboot a droplet. This is the preferred method to use if a server is not
    * responding.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action rebootDroplet(Integer dropletId)
@@ -371,13 +342,12 @@ public interface DigitalOcean {
   /**
    * Method allows you to power cycle a droplet. This will turn off the droplet and then turn it
    * back on.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action powerCycleDroplet(Integer dropletId)
@@ -385,13 +355,12 @@ public interface DigitalOcean {
 
   /**
    * Method allows you to shutdown a running droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action shutdownDroplet(Integer dropletId)
@@ -399,13 +368,12 @@ public interface DigitalOcean {
 
   /**
    * Method allows you to poweroff a running droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action powerOffDroplet(Integer dropletId)
@@ -413,13 +381,12 @@ public interface DigitalOcean {
 
   /**
    * Method allows you to poweron a powered off droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action powerOnDroplet(Integer dropletId)
@@ -428,13 +395,12 @@ public interface DigitalOcean {
   /**
    * Method will reset the root password for a droplet. Please be aware that this will reboot the
    * droplet to allow resetting the password.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action resetDropletPassword(Integer dropletId)
@@ -443,14 +409,13 @@ public interface DigitalOcean {
   /**
    * Method allows you to resize a specific droplet to a different size. This will affect the number
    * of processors and memory allocated to the droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param size of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action resizeDroplet(Integer dropletId, String size)
@@ -464,10 +429,9 @@ public interface DigitalOcean {
    * @param size of the droplet
    * @param disk whether to resize disk of the droplet or or not
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v1.0
    */
   Action resizeDroplet(Integer dropletId, String size, Boolean disk)
@@ -476,13 +440,12 @@ public interface DigitalOcean {
   /**
    * Method allows you to take a snapshot of the running droplet, which can later be restored or
    * used to create a new droplet from the same image. Please be aware this may cause a reboot.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action takeDropletSnapshot(Integer dropletId)
@@ -491,14 +454,13 @@ public interface DigitalOcean {
   /**
    * Method allows you to take a snapshot of the running droplet, which can later be restored or
    * used to create a new droplet from the same image. Please be aware this may cause a reboot.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param snapshotName the name the snapshot to be created
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action takeDropletSnapshot(Integer dropletId, String snapshotName)
@@ -508,14 +470,13 @@ public interface DigitalOcean {
    * Method allows you to restore a droplet with a previous image or snapshot. This will be a mirror
    * copy of the image or snapshot to your droplet. Be sure you have backed up any necessary
    * information prior to restore.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param imageId the id of the DigitalOcean public image or your private image
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action restoreDroplet(Integer dropletId, Integer imageId)
@@ -524,14 +485,13 @@ public interface DigitalOcean {
   /**
    * Method allows you to reinstall a droplet with a default image. This is useful if you want to
    * start again but retain the same IP address for your droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param imageId the id of the DigitalOcean public image or your private image
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action rebuildDroplet(Integer dropletId, Integer imageId)
@@ -539,13 +499,12 @@ public interface DigitalOcean {
 
   /**
    * Method enables automatic backups for your droplet's data.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Action enableDropletBackups(Integer dropletId)
@@ -553,13 +512,12 @@ public interface DigitalOcean {
 
   /**
    * Method disables automatic backups from running to backup your droplet's data.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action disableDropletBackups(Integer dropletId)
@@ -567,14 +525,13 @@ public interface DigitalOcean {
 
   /**
    * Method renames the droplet to the specified name.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param name the new name of droplet to be called
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action renameDroplet(Integer dropletId, String name)
@@ -582,14 +539,13 @@ public interface DigitalOcean {
 
   /**
    * Method changes a OS kernel for given droplet
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param kernelId the kernel id to be changed for droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Action changeDropletKernel(Integer dropletId, Integer kernelId)
@@ -597,11 +553,11 @@ public interface DigitalOcean {
 
   /**
    * Enabling IP v6 networking capability for droplet. It may be dependent on Data Center Features.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
    */
   Action enableDropletIpv6(Integer dropletId)
@@ -610,13 +566,12 @@ public interface DigitalOcean {
   /**
    * Enabling private networking capability for droplet. It may be dependent on Data Center
    * Features.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Action enableDropletPrivateNetworking(Integer dropletId)
@@ -628,10 +583,10 @@ public interface DigitalOcean {
 
   /**
    * Method returns account information for provided credentials
-   * 
+   *
    * @return ${@link Account}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
    */
   Account getAccountInfo() throws DigitalOceanException, RequestUnsuccessfulException;
@@ -642,14 +597,13 @@ public interface DigitalOcean {
 
   /**
    * Method return all the action informations, regardless of categories.
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Actions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Actions getAvailableActions(Integer pageNo, Integer perPage)
@@ -657,28 +611,26 @@ public interface DigitalOcean {
 
   /**
    * To retrieve a specific action information by action ID
-   * 
+   *
    * @param actionId the id of action
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Action getActionInfo(Integer actionId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method return all the action informations; specific to given Droplet Id
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Actions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Actions getAvailableDropletActions(Integer dropletId, Integer pageNo, Integer perPage)
@@ -686,15 +638,14 @@ public interface DigitalOcean {
 
   /**
    * Method return all the action informations; specific to given Image Id
-   * 
+   *
    * @param imageId the id of the Image
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Actions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Actions getAvailableImageActions(Integer imageId, Integer pageNo, Integer perPage)
@@ -702,15 +653,14 @@ public interface DigitalOcean {
 
   /**
    * Method retrives all actions that have been executed on a Floating IP address.
-   * 
+   *
    * @param ipAddress Floating IP address
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Actions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Actions getAvailableFloatingIPActions(String ipAddress, Integer pageNo, Integer perPage)
@@ -718,14 +668,13 @@ public interface DigitalOcean {
 
   /**
    * Method to retrieve the status of a Floating IP action.
-   * 
+   *
    * @param ipAddress Floating IP address
    * @param actionId the id of action
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Action getFloatingIPActionInfo(String ipAddress, Integer actionId)
@@ -739,31 +688,29 @@ public interface DigitalOcean {
    * Method returns all the available images that can be accessed by your OAuth Token. You will have
    * access to all public images by default, and any snapshots or backups that you have created in
    * your own account.
-   * 
+   *
    * @param pageNo of request pagination
    * @param perPage no. of items per page
    * @return {@link Images}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Images getAvailableImages(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
-   * Method returns all the available images based on
-   * <code>type={distribution or application}</code> that can be accessed by your OAuth Token.
-   * 
+   * Method returns all the available images based on <code>type={distribution or application}
+   * </code> that can be accessed by your OAuth Token.
+   *
    * @param pageNo of request pagination
    * @param perPage no. of items per page
    * @param type of action
    * @return {@link Images}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Images getAvailableImages(Integer pageNo, Integer perPage, ActionType type)
@@ -771,12 +718,12 @@ public interface DigitalOcean {
 
   /**
    * Method retrieves only the private images of a user
-   * 
+   *
    * @param pageNo of request pagination
    * @param perPage no. of items per page
    * @return {@link Images}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
    */
   Images getUserImages(Integer pageNo, Integer perPage)
@@ -784,38 +731,37 @@ public interface DigitalOcean {
 
   /**
    * Method retrieves the attributes of an image.
-   * 
+   *
    * @param imageId the image Id of the droplet/snapshot/backup images
    * @return {@link Image}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Image getImageInfo(Integer imageId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method retrieves the attributes of an image.
-   * 
+   *
    * @param slug of the public image
    * @return {@link Image}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Image getImageInfo(String slug) throws DigitalOceanException, RequestUnsuccessfulException;
-  
-  
+
   /**
    * Method creates the custom image.
-   * 
-   * <p>Refer to <a href="https://developers.digitalocean.com/documentation/v2/#create-a-custom-image">
-   * https://developers.digitalocean.com/documentation/v2/#create-a-custom-image</a></p>
-   * 
-   * <p>Sample Payload:</p>
+   *
+   * <p>Refer to <a
+   * href="https://developers.digitalocean.com/documentation/v2/#create-a-custom-image">
+   * https://developers.digitalocean.com/documentation/v2/#create-a-custom-image</a>
+   *
+   * <p>Sample Payload:
+   *
    * <pre>
    * {
    *   "name": "ubuntu-18.04-minimal",
@@ -829,26 +775,24 @@ public interface DigitalOcean {
    *   ]
    * }
    * </pre>
-   * 
-   * @param image instance with custom image attributes 
+   *
+   * @param image instance with custom image attributes
    * @return {@link Image}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.17
    */
   Image createCustomImage(Image image) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method updates the given details for an image.
-   * 
+   *
    * @param image object for update
    * @return {@link Image}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Image updateImage(Image image) throws DigitalOceanException, RequestUnsuccessfulException;
@@ -856,27 +800,25 @@ public interface DigitalOcean {
   /**
    * Method allows you to deletes an image. There is no way to restore a deleted image so be careful
    * and ensure your data is properly backed up.
-   * 
+   *
    * @param imageId of the droplet/snapshot/backup images
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Delete deleteImage(Integer imageId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method allows you to transfer an image to a specified region.
-   * 
+   *
    * @param imageId the Id of the droplet/snapshot/backup images
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Action transferImage(Integer imageId, String regionSlug)
@@ -884,13 +826,12 @@ public interface DigitalOcean {
 
   /**
    * Method allows you to convert image into snapshot
-   * 
+   *
    * @param imageId the Id of the droplet/snapshot/backup images
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Action convertImage(Integer imageId) throws DigitalOceanException, RequestUnsuccessfulException;
@@ -901,13 +842,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns all the available regions within the DigitalOcean cloud.
-   * 
+   *
    * @param pageNo for pagination
    * @return {@link Regions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Regions getAvailableRegions(Integer pageNo)
@@ -919,13 +859,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns all the available sizes that can be used to create a droplet.
-   * 
+   *
    * @param pageNo for pagination
    * @return {@link Sizes}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Sizes getAvailableSizes(Integer pageNo)
@@ -937,13 +876,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns all of your available domains from DNS control panel
-   * 
+   *
    * @param pageNo for pagination
    * @return {@link Domains}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Domains getAvailableDomains(Integer pageNo)
@@ -951,13 +889,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns the specified domain attributes and zone file info.
-   * 
+   *
    * @param domainName the name of the domain
    * @return {@link Domain}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Domain getDomainInfo(String domainName)
@@ -965,41 +902,38 @@ public interface DigitalOcean {
 
   /**
    * Method creates a new domain name with an A record for the specified [ip_address].
-   * 
+   *
    * @param domain object with name and IP address for creation
    * @return {@link Domain}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Domain createDomain(Domain domain) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method deletes the specified domain from DNS control panel
-   * 
+   *
    * @param domainName the name of the domain
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.0
    */
   Delete deleteDomain(String domainName) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method returns all of your current domain records from DNS control panel for given domain.
-   * 
+   *
    * @param domainName of the domain
    * @param pageNo of request pagination
    * @param perPage no. of items per page
    * @return {@link DomainRecords}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.1
    */
   DomainRecords getDomainRecords(String domainName, Integer pageNo, Integer perPage)
@@ -1007,15 +941,14 @@ public interface DigitalOcean {
 
   /**
    * Method creates a new domain record name with an given domain record values
-   * 
+   *
    * @param domainName of the domain
    * @param domainRecord the domain record values domain Id, record type, data, name, priority,
-   *        port, weight
+   *     port, weight
    * @return {@link DomainRecord}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.1
    */
   DomainRecord createDomainRecord(String domainName, DomainRecord domainRecord)
@@ -1023,14 +956,13 @@ public interface DigitalOcean {
 
   /**
    * Method returns the specified domain record.
-   * 
+   *
    * @param domainName of the domain
    * @param recordId of the domain
    * @return {@link DomainRecord}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.1
    */
   DomainRecord getDomainRecordInfo(String domainName, Integer recordId)
@@ -1038,16 +970,15 @@ public interface DigitalOcean {
 
   /**
    * method edits an existing domain record of the given domain.
-   * 
+   *
    * @param domainName of the domain
    * @param recordId of the domain
    * @param domainRecord the domain record values domain Id, record type, data, name, priority,
-   *        port, weight
+   *     port, weight
    * @return {@link DomainRecord}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   DomainRecord updateDomainRecord(String domainName, Integer recordId, DomainRecord domainRecord)
@@ -1055,14 +986,13 @@ public interface DigitalOcean {
 
   /**
    * Method deletes the specified domain record from domain.
-   * 
+   *
    * @param domainName of the domain
    * @param recordId of the domain
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.1
    */
   Delete deleteDomainRecord(String domainName, Integer recordId)
@@ -1074,13 +1004,12 @@ public interface DigitalOcean {
 
   /**
    * Method lists all the available public SSH keys in your account that can be added to a droplet.
-   * 
+   *
    * @param pageNo for pagination
    * @return {@link Keys}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.2
    */
   Keys getAvailableKeys(Integer pageNo) throws DigitalOceanException, RequestUnsuccessfulException;
@@ -1088,13 +1017,12 @@ public interface DigitalOcean {
   /**
    * Method shows a specific public SSH key information from your account that can be added to a
    * droplet.
-   * 
+   *
    * @param sshKeyId the SSH key Id
    * @return {@link Key}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.2
    */
   Key getKeyInfo(Integer sshKeyId) throws DigitalOceanException, RequestUnsuccessfulException;
@@ -1102,40 +1030,37 @@ public interface DigitalOcean {
   /**
    * Method shows a specific public SSH key information from your account that can be added to a
    * droplet.
-   * 
+   *
    * @param fingerprint the SSH key fingerprint
    * @return {@link Key}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Key getKeyInfo(String fingerprint) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method allows you to add a new public SSH key to your account
-   * 
+   *
    * @param newKey the {@link Key} object with sshKeyName and sshPublicKey
    * @return {@link Key}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.2
    */
   Key createKey(Key newKey) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method allows you to modify an existing SSH key in your account.
-   * 
+   *
    * @param sshKeyId the SSH key Id
    * @param newSshKeyName the new name to give the SSH key
    * @return {@link Key}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.2
    */
   Key updateKey(Integer sshKeyId, String newSshKeyName)
@@ -1143,14 +1068,13 @@ public interface DigitalOcean {
 
   /**
    * Method allows you to modify an existing SSH key in your account.
-   * 
+   *
    * @param fingerprint the SSH fingerprint
    * @param newSshKeyName the new name to give the SSH key
    * @return {@link Key}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Key updateKey(String fingerprint, String newSshKeyName)
@@ -1158,26 +1082,24 @@ public interface DigitalOcean {
 
   /**
    * Method will delete the SSH key from your account.
-   * 
+   *
    * @param sshKeyId the SSH key Id, you would like to delete
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v1.2
    */
   Delete deleteKey(Integer sshKeyId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method will delete the SSH key from your account.
-   * 
+   *
    * @param fingerprint the SSH fingerprint
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.0
    */
   Delete deleteKey(String fingerprint) throws DigitalOceanException, RequestUnsuccessfulException;
@@ -1188,14 +1110,13 @@ public interface DigitalOcean {
 
   /**
    * Method will list all of the Floating IPs available from your account.
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link FloatingIPs}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   FloatingIPs getAvailableFloatingIPs(Integer pageNo, Integer perPage)
@@ -1203,13 +1124,12 @@ public interface DigitalOcean {
 
   /**
    * Method creates a new Floating IP and assigns to the Droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @return {@link FloatingIP}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   FloatingIP createFloatingIP(Integer dropletId)
@@ -1217,13 +1137,12 @@ public interface DigitalOcean {
 
   /**
    * Method creates a new Floating IP and its reserved to a Region
-   * 
+   *
    * @param region name of the DigitalOcean region
    * @return {@link FloatingIP}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   FloatingIP createFloatingIP(String region)
@@ -1231,13 +1150,12 @@ public interface DigitalOcean {
 
   /**
    * Method retrieves the information about given Floating IP
-   * 
+   *
    * @param ipAddress Floating IP address
    * @return {@link FloatingIP}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   FloatingIP getFloatingIPInfo(String ipAddress)
@@ -1245,13 +1163,12 @@ public interface DigitalOcean {
 
   /**
    * Method deletes the Floating IP and removes it from your account.
-   * 
+   *
    * @param ipAddress Floating IP address
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Delete deleteFloatingIP(String ipAddress)
@@ -1259,14 +1176,13 @@ public interface DigitalOcean {
 
   /**
    * Method will assign Floating IP to a Droplet.
-   * 
+   *
    * @param dropletId the id of the droplet
    * @param ipAddress Floating IP address
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Action assignFloatingIP(Integer dropletId, String ipAddress)
@@ -1275,13 +1191,12 @@ public interface DigitalOcean {
   /**
    * Method will unassign Floating IP from a Droplet. The Floating IP will be reserved in the region
    * but not assigned to a Droplet.
-   * 
+   *
    * @param ipAddress Floating IP address
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.3
    */
   Action unassignFloatingIP(String ipAddress)
@@ -1292,14 +1207,13 @@ public interface DigitalOcean {
   // ===========================================
   /**
    * Method will list all of the Tags available from your account.
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Tags}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Tags getAvailableTags(Integer pageNo, Integer perPage)
@@ -1307,53 +1221,49 @@ public interface DigitalOcean {
 
   /**
    * Method will create a Tag on DigitalOcean aacount.
-   * 
+   *
    * @param name Tag Name
    * @return {@link Tag}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Tag createTag(String name) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method retrieves the Tag from DigitalOcean account.
-   * 
+   *
    * @param name Tag Name
    * @return {@link Tag}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Tag getTag(String name) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method deletes the existing Tag from DigitalOcean account.
-   * 
+   *
    * @param name Tag Name
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Delete deleteTag(String name) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method tags a tag to given list of resources on DigitalOcean account.
-   * 
+   *
    * @param name Tag Name
    * @param resources list of resource by {@link Resource} objects
    * @return {@link Response}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Response tagResources(String name, List<Resource> resources)
@@ -1361,14 +1271,13 @@ public interface DigitalOcean {
 
   /**
    * Method untags a tag from given list of resources on DigitalOcean account.
-   * 
+   *
    * @param name Tag Name
    * @param resources list of resource by {@link Resource} objects
    * @return {@link Response}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.5
    */
   Response untagResources(String name, List<Resource> resources)
@@ -1380,13 +1289,12 @@ public interface DigitalOcean {
 
   /**
    * Method will list all of the Volumes available from your account.
-   * 
+   *
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Volumes}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Volumes getAvailableVolumes(String regionSlug)
@@ -1394,40 +1302,37 @@ public interface DigitalOcean {
 
   /**
    * Method creates new volume with given details
-   * 
+   *
    * @param volume details to create new volume
    * @return {@link Volume}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Volume createVolume(Volume volume) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method shows specific volume information by identifier
-   * 
+   *
    * @param volumeId volume identifier
    * @return {@link Volume}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Volume getVolumeInfo(String volumeId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method shows volume information by name and region slug
-   * 
+   *
    * @param volumeName name of the volume
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Volumes}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Volumes getVolumeInfo(String volumeName, String regionSlug)
@@ -1435,27 +1340,25 @@ public interface DigitalOcean {
 
   /**
    * Method deletes volume by identifier
-   * 
+   *
    * @param volumeId volume identifier
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Delete deleteVolume(String volumeId) throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method deletes volume by name and region slug
-   * 
+   *
    * @param volumeName
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Delete deleteVolume(String volumeName, String regionSlug)
@@ -1463,7 +1366,7 @@ public interface DigitalOcean {
 
   /**
    * Method attaches the given volume into droplet by identifier
-   * 
+   *
    * @param dropletId droplet identifier
    * @param volumeId volume identifier
    * @param regionSlug is code name of the region aka DigitalOcean data centers
@@ -1476,15 +1379,14 @@ public interface DigitalOcean {
 
   /**
    * Method attaches the given volume into droplet by name
-   * 
+   *
    * @param dropletId droplet identifier
    * @param volumeName
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Action attachVolumeByName(Integer dropletId, String volumeName, String regionSlug)
@@ -1492,15 +1394,14 @@ public interface DigitalOcean {
 
   /**
    * Method detaches volume from the droplet by identifier
-   * 
+   *
    * @param dropletId droplet identifier
    * @param volumeId volume identifier
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Action detachVolume(Integer dropletId, String volumeId, String regionSlug)
@@ -1508,15 +1409,14 @@ public interface DigitalOcean {
 
   /**
    * Method detaches volume from the droplet by volume name
-   * 
+   *
    * @param dropletId droplet identifier
    * @param volumeName
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Action detachVolumeByName(Integer dropletId, String volumeName, String regionSlug)
@@ -1524,15 +1424,14 @@ public interface DigitalOcean {
 
   /**
    * Method resizes volume by identifier
-   * 
+   *
    * @param volumeId volume identifier
    * @param regionSlug is code name of the region aka DigitalOcean data centers
    * @param sizeGigabytes size value in GB
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Action resizeVolume(String volumeId, String regionSlug, Double sizeGigabytes)
@@ -1540,13 +1439,12 @@ public interface DigitalOcean {
 
   /**
    * Method will get all the available volume action by volume identifier
-   * 
+   *
    * @param volumeId volume identifier
    * @return {@link Actions}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Actions getAvailableVolumeActions(String volumeId)
@@ -1554,14 +1452,13 @@ public interface DigitalOcean {
 
   /**
    * Method returns specific volume action by action & volume identifier
-   * 
+   *
    * @param volumeId
    * @param actionId
    * @return {@link Action}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.7
    */
   Action getVolumeAction(String volumeId, Integer actionId)
@@ -1569,15 +1466,14 @@ public interface DigitalOcean {
 
   /**
    * Method return all of the snapshots for given volume Id
-   * 
+   *
    * @param volumeId
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Snapshots}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshots getVolumeSnapshots(String volumeId, Integer pageNo, Integer perPage)
@@ -1585,14 +1481,13 @@ public interface DigitalOcean {
 
   /**
    * Method take snapshot of given volume Id
-   * 
+   *
    * @param volumeId
    * @param snapshotName
    * @return {@link Snapshot}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshot takeVolumeSnapshot(String volumeId, String snapshotName)
@@ -1604,14 +1499,13 @@ public interface DigitalOcean {
 
   /**
    * Method return all of the snapshots available on your account
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Snapshots}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshots getAvailableSnapshots(Integer pageNo, Integer perPage)
@@ -1619,14 +1513,13 @@ public interface DigitalOcean {
 
   /**
    * Method return all of the droplet snapshots available on your account
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Snapshots}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshots getAllDropletSnapshots(Integer pageNo, Integer perPage)
@@ -1634,14 +1527,13 @@ public interface DigitalOcean {
 
   /**
    * Method return all of the volume snapshots available on your account
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Snapshots}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshots getAllVolumeSnapshots(Integer pageNo, Integer perPage)
@@ -1649,13 +1541,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns specific snapshot info by id
-   * 
+   *
    * @param snapshotId
    * @return {@link Snapshot}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Snapshot getSnaphotInfo(String snapshotId)
@@ -1663,13 +1554,12 @@ public interface DigitalOcean {
 
   /**
    * Method deletes snapshot by id
-   * 
+   *
    * @param snapshotId for snapshot
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.8
    */
   Delete deleteSnapshot(String snapshotId)
@@ -1682,19 +1572,18 @@ public interface DigitalOcean {
   /**
    * Method allows you to add a new load balancer to distribute traffic across multiple Droplets.
    *
-   * The LoadBalancer object passed in param can have a list of dropletIds set as dropletIds
+   * <p>The LoadBalancer object passed in param can have a list of dropletIds set as dropletIds
    * attribute. In this case, given Droplets will be assigned to the Load Balancer.
    *
-   * You may also use a Droplet tag to assign a group of Droplets to Load Balancer in place of a
+   * <p>You may also use a Droplet tag to assign a group of Droplets to Load Balancer in place of a
    * list of Droplet IDs. In this case, set the tag attribute of the LoadBalancer object passed in
    * param.
    *
    * @param loadBalancer the instance of the loadBalancer class
    * @return {@link LoadBalancer}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   LoadBalancer createLoadBalancer(LoadBalancer loadBalancer)
@@ -1705,10 +1594,9 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the droplet
    * @return {@link LoadBalancer}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   LoadBalancer getLoadBalancerInfo(String loadBalancerId)
@@ -1721,12 +1609,11 @@ public interface DigitalOcean {
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link LoadBalancers}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
-   **/
+   */
   LoadBalancers getAvailableLoadBalancers(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
@@ -1738,10 +1625,9 @@ public interface DigitalOcean {
    *
    * @param loadBalancer the instance of the loadBalancer class
    * @return {@link LoadBalancer}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   LoadBalancer updateLoadBalancer(LoadBalancer loadBalancer)
@@ -1752,12 +1638,11 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the loadBalancer
    * @param dropletIds an array containing the IDs of the Droplets to be assigned to the Load
-   *        Balancer instance.
+   *     Balancer instance.
    * @return {@link Response}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   Response addDropletsToLoadBalancer(String loadBalancerId, List<Integer> dropletIds)
@@ -1768,12 +1653,11 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the loadBalancer
    * @param dropletIds an array containing the IDs of the Droplets to be removed from the Load
-   *        Balancer instance.
+   *     Balancer instance.
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   Delete removeDropletsFromLoadBalancer(String loadBalancerId, List<Integer> dropletIds)
@@ -1784,16 +1668,15 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the loadBalancer
    * @param forwardingRules an array containing the Forwarding Rules to add to the Load Balancer
-   *        instance.
+   *     instance.
    * @return {@link Response}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
-  Response addForwardingRulesToLoadBalancer(String loadBalancerId,
-      List<ForwardingRules> forwardingRules)
+  Response addForwardingRulesToLoadBalancer(
+      String loadBalancerId, List<ForwardingRules> forwardingRules)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
@@ -1801,16 +1684,15 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the loadBalancer
    * @param forwardingRules an array containing the Forwarding Rules to remove from the Load
-   *        Balancer instance.
+   *     Balancer instance.
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
-  Delete removeForwardingRulesFromLoadBalancer(String loadBalancerId,
-      List<ForwardingRules> forwardingRules)
+  Delete removeForwardingRulesFromLoadBalancer(
+      String loadBalancerId, List<ForwardingRules> forwardingRules)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
@@ -1819,10 +1701,9 @@ public interface DigitalOcean {
    *
    * @param loadBalancerId the id of the loadBalancer
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.11
    */
   Delete deleteLoadBalancer(String loadBalancerId)
@@ -1838,25 +1719,21 @@ public interface DigitalOcean {
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link LoadBalancers}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.12
-   **/
+   */
   Certificates getAvailableCertificates(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
-   * <p>
    * Method allows you to create a new certificate. See the required parameters section below for an
    * explanation of the variables that are needed to create a new certificate.
-   * </p>
-   * <p>
-   * Create a instance of {@link Certificate} class and populated the certificate object
+   *
+   * <p>Create a instance of {@link Certificate} class and populated the certificate object
    * appropriately. Required values are -
-   * </p>
-   * 
+   *
    * <pre>
    * {
    *    "name": "web-cert-01",
@@ -1865,28 +1742,25 @@ public interface DigitalOcean {
    *    "certificate_chain": "-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
    * }
    * </pre>
-   * 
+   *
    * @param certificate the instance of the Certificate class
    * @return {@link Certificate}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.12
    */
   Certificate createCertificate(Certificate certificate)
       throws DigitalOceanException, RequestUnsuccessfulException;
-  
+
   /**
-   * <p>
-   * Method allows you to create a new Let's Encrypt certificate. See the required parameters section below for an
-   * explanation of the variables that are needed to create a new Let's Encrypt certificate.
-   * </p>
-   * <p>
-   * Create a instance of {@link Certificate} class and populated the certificate object
+   * Method allows you to create a new Let's Encrypt certificate. See the required parameters
+   * section below for an explanation of the variables that are needed to create a new Let's Encrypt
+   * certificate.
+   *
+   * <p>Create a instance of {@link Certificate} class and populated the certificate object
    * appropriately. Required values are -
-   * </p>
-   * 
+   *
    * <pre>
    * {
    *    "name": "le-cert-01",
@@ -1894,13 +1768,12 @@ public interface DigitalOcean {
    *    "dns_names": ["www.example.com","example.com"]
    * }
    * </pre>
-   * 
+   *
    * @param certificate the instance of the Certificate class
    * @return {@link Certificate}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.12
    */
   Certificate createLetsEncryptCertificate(Certificate certificate)
@@ -1908,13 +1781,12 @@ public interface DigitalOcean {
 
   /**
    * Method returns the Certificate information for given certificate ID.
-   * 
+   *
    * @param certificateId the id of the certificate
    * @return {@link Certificate}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.12
    */
   Certificate getCertificateInfo(String certificateId)
@@ -1925,10 +1797,9 @@ public interface DigitalOcean {
    *
    * @param certificateId the id of the certificate
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.12
    */
   Delete deleteCertificate(String certificateId)
@@ -1941,19 +1812,18 @@ public interface DigitalOcean {
   /**
    * Method allows you to add a new firewall to restrict network access to and from a Droplet.
    *
-   * The Firewall object passed in param can have a list of dropletIds set as dropletIds attribute.
-   * In this case, given Droplets will use the Firewall rules.
+   * <p>The Firewall object passed in param can have a list of dropletIds set as dropletIds
+   * attribute. In this case, given Droplets will use the Firewall rules.
    *
-   * You may also use a Droplet tag to assign a group of Droplets to use the Firewall in place of a
-   * list of Droplet IDs. In this case, set the tag attribute of the Firewall object passed in
+   * <p>You may also use a Droplet tag to assign a group of Droplets to use the Firewall in place of
+   * a list of Droplet IDs. In this case, set the tag attribute of the Firewall object passed in
    * param.
    *
    * @param firewall the instance of the firewall class
    * @return {@link Firewall}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.16
    */
   Firewall createFirewall(Firewall firewall)
@@ -1964,10 +1834,9 @@ public interface DigitalOcean {
    *
    * @param firewallId the id of the firewall
    * @return {@link Firewall}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.16
    */
   Firewall getFirewallInfo(String firewallId)
@@ -1981,10 +1850,9 @@ public interface DigitalOcean {
    *
    * @param firewall the instance of the firewall class
    * @return {@link Firewall}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.16
    */
   Firewall updateFirewall(Firewall firewall)
@@ -1996,10 +1864,9 @@ public interface DigitalOcean {
    *
    * @param firewallId the id of the firewall
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.16
    */
   Delete deleteFirewall(String firewallId)
@@ -2011,10 +1878,9 @@ public interface DigitalOcean {
    * @param firewallId the id of the firewall to add droplets to
    * @param dropletIds the list of of droplet IDs to add to the firewall
    * @return {@link Response} A generic HTTP status response
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.17
    */
   Response addDropletsToFirewall(String firewallId, List<Integer> dropletIds)
@@ -2026,29 +1892,26 @@ public interface DigitalOcean {
    * @param firewallId the id of the firewall
    * @param dropletIds the list of droplet IDs to be removed from the firewall instance.
    * @return {@link Delete}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   *
    * @since v2.17
    */
   Delete removeDropletsFromFirewall(String firewallId, List<Integer> dropletIds)
-    throws DigitalOceanException, RequestUnsuccessfulException;
+      throws DigitalOceanException, RequestUnsuccessfulException;
 
   /**
    * Method returns all available firewalls that are currently running in your account. All
    * available API information is presented for each firewall.
-   * 
+   *
    * @param pageNo for pagination
    * @param perPage no. of items per page
    * @return {@link Firewalls}
-   * @throws DigitalOceanException if request had interruption [
-   *         <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
+   * @throws DigitalOceanException if request had interruption [ <code>
+   *     HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>]
    * @throws RequestUnsuccessfulException if any RESTful request unsuccessful from wrapper method
-   * 
    * @since v2.16
-   **/
+   */
   Firewalls getAvailableFirewalls(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException;
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/common/ActionStatus.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ActionStatus.java
@@ -1,45 +1,41 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Action Status
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum ActionStatus {
-
   @SerializedName("completed")
   COMPLETED("completed"),
-  
+
   @SerializedName("in-progress")
   IN_PROGRESS("in-progress"),
-  
+
   @SerializedName("errored")
   ERRORED("errored");
 

--- a/src/main/java/com/myjeeva/digitalocean/common/ActionType.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ActionType.java
@@ -1,39 +1,35 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Droplet &amp; Image Action Type
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum ActionType {
-  
   @SerializedName("create")
   CREATE("create"),
 
@@ -72,7 +68,7 @@ public enum ActionType {
 
   @SerializedName("enable_ipv6")
   ENABLE_IPV6("enable_ipv6"),
-  
+
   @SerializedName("enable_backups")
   ENABLE_BACKUPS("enable_backups"),
 
@@ -90,10 +86,10 @@ public enum ActionType {
 
   @SerializedName("transfer")
   TRANSFER("transfer"),
-  
+
   @SerializedName("convert")
   CONVERT("convert"),
-  
+
   @SerializedName("convert_to_snapshot")
   CONVERT_TO_SNAPSHOT("convert_to_snapshot"),
 
@@ -102,22 +98,26 @@ public enum ActionType {
 
   @SerializedName("application")
   APPLICATION("application"),
-  
+
   @SerializedName("assign_ip")
   ASSIGN_FLOATING_IP("assign_ip"),
-  
+
   @SerializedName("unassign_ip")
   UNASSIGN_FLOATING_IP("unassign_ip"),
-  
+
   @SerializedName("reserve_ip")
   RESERVE_FLOATING_IP("reserve_ip"),
-  
-  @SerializedName(value = "attach", alternate = {"attach_volume"}) 
+
+  @SerializedName(
+      value = "attach",
+      alternate = {"attach_volume"})
   ATTACH("attach"),
-  
-  @SerializedName(value = "detach", alternate = {"detach_volume"})
+
+  @SerializedName(
+      value = "detach",
+      alternate = {"detach_volume"})
   DETACH("detach");
-  
+
   private String value;
 
   private ActionType(String value) {

--- a/src/main/java/com/myjeeva/digitalocean/common/ApiAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ApiAction.java
@@ -1,24 +1,23 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
 import com.myjeeva.digitalocean.pojo.Account;
@@ -58,9 +57,8 @@ import com.myjeeva.digitalocean.pojo.Volumes;
 
 /**
  * Enumeration of DigitalOcean RESTful resource information.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum ApiAction {
@@ -71,7 +69,7 @@ public enum ApiAction {
   GET_DROPLET_SNAPSHOTS("/droplets/%s/snapshots", "snapshots", RequestMethod.GET, Snapshots.class),
   GET_DROPLET_BACKUPS("/droplets/%s/backups", "backups", RequestMethod.GET, Backups.class),
   GET_DROPLET_NEIGHBORS("/droplets/%s/neighbors", "droplets", RequestMethod.GET, Droplets.class),
-  GET_DROPLET_INFO("/droplets/%s", "droplet", RequestMethod.GET, Droplet.class),  
+  GET_DROPLET_INFO("/droplets/%s", "droplet", RequestMethod.GET, Droplet.class),
   CREATE_DROPLET("/droplets", "droplet", RequestMethod.POST, Droplet.class),
   CREATE_DROPLETS("/droplets", "droplets", RequestMethod.POST, Droplets.class),
   DELETE_DROPLET("/droplets/%s", "response", RequestMethod.DELETE, Delete.class),
@@ -80,7 +78,7 @@ public enum ApiAction {
   POWER_CYCLE_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   SHUTDOWN_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   POWER_OFF_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
-  POWER_ON_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class), 
+  POWER_ON_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   RESET_DROPLET_PASSWORD("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   RESIZE_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   RESTORE_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
@@ -90,69 +88,67 @@ public enum ApiAction {
   ENABLE_DROPLET_IPV6("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   ENABLE_DROPLET_BACKUPS("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   DISABLE_DROPLET_BACKUPS("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
-  ENABLE_DROPLET_PRIVATE_NETWORKING("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
+  ENABLE_DROPLET_PRIVATE_NETWORKING(
+      "/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
   SNAPSHOT_DROPLET("/droplets/%s/actions", "action", RequestMethod.POST, Action.class),
 
   // Account
   GET_ACCOUNT_INFO("/account", "account", RequestMethod.GET, Account.class),
-  
-  
+
   // Reports
-  ALL_DROPLET_NEIGHBORS("/reports/droplet_neighbors", "neighbors", RequestMethod.GET, Neighbors.class),
-  
-  
+  ALL_DROPLET_NEIGHBORS(
+      "/reports/droplet_neighbors", "neighbors", RequestMethod.GET, Neighbors.class),
+
   // Action
   AVAILABLE_ACTIONS("/actions", "actions", RequestMethod.GET, Actions.class),
   GET_ACTION_INFO("/actions/%s", "action", RequestMethod.GET, Action.class),
   GET_DROPLET_ACTIONS("/droplets/%s/actions", "actions", RequestMethod.GET, Actions.class),
   GET_IMAGE_ACTIONS("/images/%s/actions", "actions", RequestMethod.GET, Actions.class),
   GET_FLOATING_IP_ACTIONS("/floating_ips/%s/actions", "actions", RequestMethod.GET, Actions.class),
-  GET_FLOATING_IP_ACTION_INFO("/floating_ips/%s/actions/%s", "action", RequestMethod.GET, Action.class),
+  GET_FLOATING_IP_ACTION_INFO(
+      "/floating_ips/%s/actions/%s", "action", RequestMethod.GET, Action.class),
   GET_VOLUME_ACTIONS("/volumes/%s/actions", "actions", RequestMethod.GET, Actions.class),
   GET_VOLUME_ACTION("/volumes/%s/actions/%s", "action", RequestMethod.GET, Action.class),
-  
-  
+
   // Image
-  AVAILABLE_IMAGES("/images", "images", RequestMethod.GET, Images.class),  
+  AVAILABLE_IMAGES("/images", "images", RequestMethod.GET, Images.class),
   GET_IMAGE_INFO("/images/%s", "image", RequestMethod.GET, Image.class),
   CREATE_CUSTOM_IMAGE("/images", "image", RequestMethod.POST, Image.class),
   UPDATE_IMAGE_INFO("/images/%s", "image", RequestMethod.PUT, Image.class),
   DELETE_IMAGE("/images/%s", "response", RequestMethod.DELETE, Delete.class),
   TRANSFER_IMAGE("/images/%s/actions", "action", RequestMethod.POST, Action.class),
   CONVERT_IMAGE("/images/%s/actions", "action", RequestMethod.POST, Action.class),
-  
-  
+
   // Region
   AVAILABLE_REGIONS("/regions", "regions", RequestMethod.GET, Regions.class),
-  
-  
+
   // Size
   AVAILABLE_SIZES("/sizes", "sizes", RequestMethod.GET, Sizes.class),
-  
-  
+
   // Domain
   AVAILABLE_DOMAINS("/domains", "domains", RequestMethod.GET, Domains.class),
   GET_DOMAIN_INFO("/domains/%s", "domain", RequestMethod.GET, Domain.class),
-  CREATE_DOMAIN("/domains", "domain", RequestMethod.POST, Domain.class),  
+  CREATE_DOMAIN("/domains", "domain", RequestMethod.POST, Domain.class),
   DELETE_DOMAIN("/domains/%s", "response", RequestMethod.DELETE, Delete.class),
-  
-  
+
   // Domain Record
-  GET_DOMAIN_RECORDS("/domains/%s/records", "domain_records", RequestMethod.GET, DomainRecords.class),
-  GET_DOMAIN_RECORD_INFO("/domains/%s/records/%s", "domain_record", RequestMethod.GET, DomainRecord.class),
-  CREATE_DOMAIN_RECORD("/domains/%s/records", "domain_record", RequestMethod.POST, DomainRecord.class),  
-  UPDATE_DOMAIN_RECORD("/domains/%s/records/%s", "domain_record", RequestMethod.PUT, DomainRecord.class),
+  GET_DOMAIN_RECORDS(
+      "/domains/%s/records", "domain_records", RequestMethod.GET, DomainRecords.class),
+  GET_DOMAIN_RECORD_INFO(
+      "/domains/%s/records/%s", "domain_record", RequestMethod.GET, DomainRecord.class),
+  CREATE_DOMAIN_RECORD(
+      "/domains/%s/records", "domain_record", RequestMethod.POST, DomainRecord.class),
+  UPDATE_DOMAIN_RECORD(
+      "/domains/%s/records/%s", "domain_record", RequestMethod.PUT, DomainRecord.class),
   DELETE_DOMAIN_RECORD("/domains/%s/records/%s", "response", RequestMethod.DELETE, Delete.class),
-  
-  
+
   // Key
   AVAILABLE_KEYS("/account/keys", "ssh_keys", RequestMethod.GET, Keys.class),
   GET_KEY_INFO("/account/keys/%s", "ssh_key", RequestMethod.GET, Key.class),
-  CREATE_KEY("/account/keys", "ssh_key", RequestMethod.POST, Key.class),  
+  CREATE_KEY("/account/keys", "ssh_key", RequestMethod.POST, Key.class),
   UPDATE_KEY("/account/keys/%s", "ssh_key", RequestMethod.PUT, Key.class),
   DELETE_KEY("/account/keys/%s", "response", RequestMethod.DELETE, Delete.class),
-  
-  
+
   // Floating IP
   FLOATING_IPS("/floating_ips", "floating_ips", RequestMethod.GET, FloatingIPs.class),
   CREATE_FLOATING_IP("/floating_ips", "floating_ip", RequestMethod.POST, FloatingIP.class),
@@ -160,8 +156,7 @@ public enum ApiAction {
   DELETE_FLOATING_IP("/floating_ips/%s", "response", RequestMethod.DELETE, Delete.class),
   ASSIGN_FLOATING_IP("/floating_ips/%s/actions", "action", RequestMethod.POST, Action.class),
   UNASSIGN_FLOATING_IP("/floating_ips/%s/actions", "action", RequestMethod.POST, Action.class),
-  
-  
+
   // Tags
   AVAILABLE_TAGS("/tags", "tags", RequestMethod.GET, Tags.class),
   CREATE_TAG("/tags", "tag", RequestMethod.POST, Tag.class),
@@ -170,7 +165,6 @@ public enum ApiAction {
   TAG_RESOURCE("/tags/%s/resources", "response", RequestMethod.POST, Response.class),
   UNTAG_RESOURCE("/tags/%s/resources", "response", RequestMethod.DELETE, Response.class),
 
-  
   // Volumes
   AVAILABLE_VOLUMES("/volumes", "volumes", RequestMethod.GET, Volumes.class),
   CREATE_VOLUME("/volumes", "volume", RequestMethod.POST, Volume.class),
@@ -183,27 +177,31 @@ public enum ApiAction {
   GET_VOLUME_SNAPSHOTS("/volumes/%s/snapshots", "snapshots", RequestMethod.GET, Snapshots.class),
   SNAPSHOT_VOLUME("/volumes/%s/snapshots", "snapshot", RequestMethod.POST, Snapshot.class),
 
-
   // Snapshots
   AVAILABLE_SNAPSHOTS("/snapshots", "snapshots", RequestMethod.GET, Snapshots.class),
   ALL_DROPLET_SNAPSHOTS("/snapshots", "snapshots", RequestMethod.GET, Snapshots.class),
   ALL_VOLUME_SNAPSHOTS("/snapshots", "snapshots", RequestMethod.GET, Snapshots.class),
   GET_SNAPSHOT_INFO("/snapshots/%s", "snapshot", RequestMethod.GET, Snapshot.class),
   DELETE_SNAPSHOT("/snapshots/%s", "response", RequestMethod.DELETE, Delete.class),
-  
 
   // Load Balancers
   CREATE_LOAD_BALANCER("/load_balancers", "load_balancer", RequestMethod.POST, LoadBalancer.class),
-  GET_LOAD_BALANCER_INFO("/load_balancers/%s", "load_balancer", RequestMethod.GET, LoadBalancer.class),
-  AVAILABLE_LOAD_BALANCERS("/load_balancers", "load_balancers", RequestMethod.GET, LoadBalancers.class),
-  UPDATE_LOAD_BALANCER("/load_balancers/%s", "load_balancer", RequestMethod.PUT, LoadBalancer.class),
-  ADD_DROPLET_TO_LOAD_BALANCER("/load_balancers/%s/droplets", "response", RequestMethod.POST, Response.class),
-  REMOVE_DROPLET_FROM_LOAD_BALANCER("/load_balancers/%s/droplets", "response", RequestMethod.DELETE, Delete.class),
-  ADD_FORWARDING_RULES_TO_LOAD_BALANCER("/load_balancers/%s/forwarding_rules", "response", RequestMethod.POST, Response.class),
-  REMOVE_FORWARDING_RULES_FROM_LOAD_BALANCER("/load_balancers/%s/forwarding_rules", "response", RequestMethod.DELETE, Delete.class),
+  GET_LOAD_BALANCER_INFO(
+      "/load_balancers/%s", "load_balancer", RequestMethod.GET, LoadBalancer.class),
+  AVAILABLE_LOAD_BALANCERS(
+      "/load_balancers", "load_balancers", RequestMethod.GET, LoadBalancers.class),
+  UPDATE_LOAD_BALANCER(
+      "/load_balancers/%s", "load_balancer", RequestMethod.PUT, LoadBalancer.class),
+  ADD_DROPLET_TO_LOAD_BALANCER(
+      "/load_balancers/%s/droplets", "response", RequestMethod.POST, Response.class),
+  REMOVE_DROPLET_FROM_LOAD_BALANCER(
+      "/load_balancers/%s/droplets", "response", RequestMethod.DELETE, Delete.class),
+  ADD_FORWARDING_RULES_TO_LOAD_BALANCER(
+      "/load_balancers/%s/forwarding_rules", "response", RequestMethod.POST, Response.class),
+  REMOVE_FORWARDING_RULES_FROM_LOAD_BALANCER(
+      "/load_balancers/%s/forwarding_rules", "response", RequestMethod.DELETE, Delete.class),
   DELETE_LOAD_BALANCER("/load_balancers/%s", "response", RequestMethod.DELETE, Delete.class),
-  
-  
+
   // Certificates
   AVAILABLE_CERTIFICATES("/certificates", "certificates", RequestMethod.GET, Certificates.class),
   GET_CERTIFICATE_INFO("/certificates/%s", "certificate", RequestMethod.GET, Certificate.class),
@@ -217,12 +215,13 @@ public enum ApiAction {
   DELETE_FIREWALL("/firewalls/%s", "response", RequestMethod.DELETE, Delete.class),
   AVAILABLE_FIREWALLS("/firewalls", "firewalls", RequestMethod.GET, Firewalls.class),
   ADD_DROPLET_TO_FIREWALL("/firewalls/%s/droplets", "response", RequestMethod.POST, Response.class),
-  REMOVE_DROPLET_FROM_FIREWALL("/firewalls/%s/droplets", "response", RequestMethod.DELETE, Delete.class);
+  REMOVE_DROPLET_FROM_FIREWALL(
+      "/firewalls/%s/droplets", "response", RequestMethod.DELETE, Delete.class);
 
   private String path;
 
   private String elementName;
-  
+
   private RequestMethod method;
 
   private Class<?> clazz;
@@ -238,7 +237,7 @@ public enum ApiAction {
   ApiAction(String path, String elementName, RequestMethod method) {
     this(path, elementName, method, null);
   }
-  
+
   ApiAction(String path, String elementName, RequestMethod method, Class<?> clazz) {
     this.path = path;
     this.elementName = elementName;
@@ -246,30 +245,22 @@ public enum ApiAction {
     this.clazz = clazz;
   }
 
-  /**
-   * @return the path
-   */
+  /** @return the path */
   public String getPath() {
     return path;
   }
 
-  /**
-   * @return the elementName
-   */
+  /** @return the elementName */
   public String getElementName() {
     return elementName;
   }
 
-  /**
-   * @return the method
-   */
+  /** @return the method */
   public RequestMethod getMethod() {
     return method;
   }
 
-  /**
-   * @return the clazz
-   */
+  /** @return the clazz */
   public Class<?> getClazz() {
     return clazz;
   }

--- a/src/main/java/com/myjeeva/digitalocean/common/CaaTagType.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/CaaTagType.java
@@ -1,45 +1,37 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
+import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
- * <p>
  * Enumeration of DigitalOcean CAA Tag Types. Valid values are "issue", "issuewild", or "iodef".
- * </p>
- * 
- * <p>
- * More info: https://developers.digitalocean.com/documentation/v2/#domain-records/
- * </p>
- * 
+ *
+ * <p>More info: https://developers.digitalocean.com/documentation/v2/#domain-records/
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.15
  */
 public enum CaaTagType {
-
   @SerializedName("issue")
   ISSUE("issue"),
 

--- a/src/main/java/com/myjeeva/digitalocean/common/CertificateState.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/CertificateState.java
@@ -1,45 +1,41 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Certificate states.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.17
  */
 public enum CertificateState {
-
   @SerializedName("pending")
   PENDING("pending"),
-  
+
   @SerializedName("verified")
   VERIFIED("verified"),
-  
+
   @SerializedName("error")
   ERROR("error");
 

--- a/src/main/java/com/myjeeva/digitalocean/common/Constants.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/Constants.java
@@ -1,34 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
 import org.apache.http.HttpHeaders;
 
-
 /**
  * DigitalOcean API client Constants
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v1.0
  */
 public interface Constants {

--- a/src/main/java/com/myjeeva/digitalocean/common/DropletStatus.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/DropletStatus.java
@@ -1,49 +1,45 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean droplet states.
- * 
+ *
  * @author Robert Gründler (robert@dubture.com)
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v1.5
  */
 public enum DropletStatus {
-
   @SerializedName("new")
   NEW("new"),
-  
+
   @SerializedName("active")
   ACTIVE("active"),
-  
+
   @SerializedName("off")
   OFF("off"),
-  
+
   @SerializedName("archive")
   ARCHIVE("archive");
 

--- a/src/main/java/com/myjeeva/digitalocean/common/ImageStatus.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ImageStatus.java
@@ -1,45 +1,41 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Image Status
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.17
  */
 public enum ImageStatus {
-
   @SerializedName("new")
   NEW("new"),
 
   @SerializedName("available")
   AVAILABLE("available"),
-  
+
   @SerializedName("pending")
   PENDING("pending"),
 

--- a/src/main/java/com/myjeeva/digitalocean/common/ImageType.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ImageType.java
@@ -1,47 +1,44 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Image Types
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum ImageType {
-
   @SerializedName("snapshot")
   SNAPSHOT("snapshot"),
 
   @SerializedName("backup")
   BACKUP("backup"),
-  
+
   /**
-   * #89 - https://developers.digitalocean.com/documentation/changelog/api-v2/support-for-custom-images-and-image-tagging/
+   * #89 -
+   * https://developers.digitalocean.com/documentation/changelog/api-v2/support-for-custom-images-and-image-tagging/
    */
   @SerializedName("custom")
   CUSTOM("custom"),

--- a/src/main/java/com/myjeeva/digitalocean/common/LoadBalancerStatus.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/LoadBalancerStatus.java
@@ -1,70 +1,66 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean load balancer status.
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public enum LoadBalancerStatus {
+  @SerializedName("new")
+  NEW("new"),
 
-    @SerializedName("new")
-    NEW("new"),
+  @SerializedName("active")
+  ACTIVE("active"),
 
-    @SerializedName("active")
-    ACTIVE("active"),
+  @SerializedName("errored")
+  ERRORED("errored");
 
-    @SerializedName("errored")
-    ERRORED("errored");
+  private String value;
 
-    private String value;
+  private LoadBalancerStatus(String value) {
+    this.value = value;
+  }
 
-    private LoadBalancerStatus(String value) {
-        this.value = value;
+  public static LoadBalancerStatus fromValue(String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("Value cannot be null or empty!");
     }
 
-    public static LoadBalancerStatus fromValue(String value) {
-        if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException("Value cannot be null or empty!");
-        }
-
-        for (LoadBalancerStatus ds : LoadBalancerStatus.values()) {
-            if (value.equalsIgnoreCase(ds.value)) {
-                return ds;
-            }
-        }
-
-        throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+    for (LoadBalancerStatus ds : LoadBalancerStatus.values()) {
+      if (value.equalsIgnoreCase(ds.value)) {
+        return ds;
+      }
     }
 
-    @Override
-    public String toString() {
-        return this.value;
-    }
+    throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
 }

--- a/src/main/java/com/myjeeva/digitalocean/common/LoadBalancingAlgorithm.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/LoadBalancingAlgorithm.java
@@ -1,67 +1,63 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean load balancing algorithms.
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public enum LoadBalancingAlgorithm {
+  @SerializedName("round_robin")
+  ROUND_ROBIN("round_robin"),
 
-    @SerializedName("round_robin")
-    ROUND_ROBIN("round_robin"),
+  @SerializedName("least_connections")
+  LEAST_CONNECTIONS("least_connections");
 
-    @SerializedName("least_connections")
-    LEAST_CONNECTIONS("least_connections");
+  private String value;
 
-    private String value;
+  private LoadBalancingAlgorithm(String value) {
+    this.value = value;
+  }
 
-    private LoadBalancingAlgorithm(String value) {
-        this.value = value;
+  public static LoadBalancingAlgorithm fromValue(String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("Value cannot be null or empty!");
     }
 
-    public static LoadBalancingAlgorithm fromValue(String value) {
-        if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException("Value cannot be null or empty!");
-        }
-
-        for (LoadBalancingAlgorithm ds : LoadBalancingAlgorithm.values()) {
-            if (value.equalsIgnoreCase(ds.value)) {
-                return ds;
-            }
-        }
-
-        throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+    for (LoadBalancingAlgorithm ds : LoadBalancingAlgorithm.values()) {
+      if (value.equalsIgnoreCase(ds.value)) {
+        return ds;
+      }
     }
 
-    @Override
-    public String toString() {
-        return this.value;
-    }
+    throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
 }

--- a/src/main/java/com/myjeeva/digitalocean/common/Protocol.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/Protocol.java
@@ -1,70 +1,66 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of protocol used in forwarding rules .
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public enum Protocol {
+  @SerializedName("http")
+  HTTP("http"),
 
-    @SerializedName("http")
-    HTTP("http"),
+  @SerializedName("https")
+  HTTPS("https"),
 
-    @SerializedName("https")
-    HTTPS("https"),
+  @SerializedName("tcp")
+  TCP("tcp");
 
-    @SerializedName("tcp")
-    TCP("tcp");
+  private String value;
 
-    private String value;
+  private Protocol(String value) {
+    this.value = value;
+  }
 
-    private Protocol(String value) {
-        this.value = value;
+  public static Protocol fromValue(String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("Value cannot be null or empty!");
     }
 
-    public static Protocol fromValue(String value) {
-        if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException("Value cannot be null or empty!");
-        }
-
-        for (Protocol ds : Protocol.values()) {
-            if (value.equalsIgnoreCase(ds.value)) {
-                return ds;
-            }
-        }
-
-        throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+    for (Protocol ds : Protocol.values()) {
+      if (value.equalsIgnoreCase(ds.value)) {
+        return ds;
+      }
     }
 
-    @Override
-    public String toString() {
-        return this.value;
-    }
+    throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
 }

--- a/src/main/java/com/myjeeva/digitalocean/common/RequestMethod.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/RequestMethod.java
@@ -1,33 +1,34 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
 /**
  * Enumeration of HTTP Methods
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum RequestMethod {
-  GET, POST, PUT, DELETE;
+  GET,
+  POST,
+  PUT,
+  DELETE;
 }

--- a/src/main/java/com/myjeeva/digitalocean/common/ResourceType.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/ResourceType.java
@@ -1,57 +1,52 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of DigitalOcean Resource Types
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public enum ResourceType {
-
   @SerializedName("droplet")
   DROPLET("droplet"),
-  
+
   @SerializedName("volume")
   VOLUME("volume"),
-  
+
   @SerializedName("image")
   IMAGE("image"),
-  
+
   @SerializedName("backend")
   BACKEND("backend"),
-  
+
   @SerializedName("floating_ip")
   FLOATING_IP("floating_ip"),
 
   @SerializedName("load_balancer")
   LOAD_BALANCER("load_balancer");
-
 
   private String value;
 

--- a/src/main/java/com/myjeeva/digitalocean/common/StickySessionType.java
+++ b/src/main/java/com/myjeeva/digitalocean/common/StickySessionType.java
@@ -1,67 +1,63 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.common;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Enumeration of sticky session types .
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public enum StickySessionType {
+  @SerializedName("cookies")
+  Cookies("cookies"),
 
-    @SerializedName("cookies")
-    Cookies("cookies"),
+  @SerializedName("none")
+  None("none");
 
-    @SerializedName("none")
-    None("none");
+  private String value;
 
-    private String value;
+  private StickySessionType(String value) {
+    this.value = value;
+  }
 
-    private StickySessionType(String value) {
-        this.value = value;
+  public static StickySessionType fromValue(String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("Value cannot be null or empty!");
     }
 
-    public static StickySessionType fromValue(String value) {
-        if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException("Value cannot be null or empty!");
-        }
-
-        for (StickySessionType ds : StickySessionType.values()) {
-            if (value.equalsIgnoreCase(ds.value)) {
-                return ds;
-            }
-        }
-
-        throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+    for (StickySessionType ds : StickySessionType.values()) {
+      if (value.equalsIgnoreCase(ds.value)) {
+        return ds;
+      }
     }
 
-    @Override
-    public String toString() {
-        return this.value;
-    }
+    throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
 }

--- a/src/main/java/com/myjeeva/digitalocean/exception/DigitalOceanException.java
+++ b/src/main/java/com/myjeeva/digitalocean/exception/DigitalOceanException.java
@@ -1,30 +1,29 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.exception;
 
 /**
- * <code>DigitalOceanException</code> will be thrown, when request had interruption [
- * <code>HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>] DigitalOcean API
- * 
+ * <code>DigitalOceanException</code> will be thrown, when request had interruption [ <code>
+ * HTTP status code &gt;= 400 &amp;&amp; &lt; 510</code>] DigitalOcean API
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class DigitalOceanException extends Exception {
@@ -49,16 +48,12 @@ public class DigitalOceanException extends Exception {
     this.httpStatusCode = statusCode;
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public String getId() {
     return id;
   }
 
-  /**
-   * @return the httpStatusCode
-   */
+  /** @return the httpStatusCode */
   public int getHttpStatusCode() {
     return httpStatusCode;
   }

--- a/src/main/java/com/myjeeva/digitalocean/exception/RequestUnsuccessfulException.java
+++ b/src/main/java/com/myjeeva/digitalocean/exception/RequestUnsuccessfulException.java
@@ -1,30 +1,29 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.exception;
 
 /**
- * <code>RequestUnsuccessfulException</code> will be thrown if any RESTful request unsuccessful
- * from wrapper method
- * 
+ * <code>RequestUnsuccessfulException</code> will be thrown if any RESTful request unsuccessful from
+ * wrapper method
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class RequestUnsuccessfulException extends Exception {
@@ -38,5 +37,4 @@ public class RequestUnsuccessfulException extends Exception {
   public RequestUnsuccessfulException(String msg, Throwable t) {
     super(msg, t);
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/http/client/methods/CustomHttpDelete.java
+++ b/src/main/java/com/myjeeva/digitalocean/http/client/methods/CustomHttpDelete.java
@@ -1,41 +1,36 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.http.client.methods;
 
-import java.net.URI;
-
-import org.apache.http.client.methods.HttpPost;
-
 import com.myjeeva.digitalocean.DigitalOcean;
+import java.net.URI;
+import org.apache.http.client.methods.HttpPost;
 
 /**
  * Custom delete HTTP client method with Payload support.
- * <p>
- * To begin with {@link DigitalOcean#untagResources(String, java.util.List)} method needs Payload
+ *
+ * <p>To begin with {@link DigitalOcean#untagResources(String, java.util.List)} method needs Payload
  * support.
- * </p>
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class CustomHttpDelete extends HttpPost {
@@ -52,5 +47,4 @@ public class CustomHttpDelete extends HttpPost {
   public String getMethod() {
     return "DELETE";
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/impl/ApiRequest.java
+++ b/src/main/java/com/myjeeva/digitalocean/impl/ApiRequest.java
@@ -1,36 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.impl;
-
-import java.util.Map;
 
 import com.myjeeva.digitalocean.common.ApiAction;
 import com.myjeeva.digitalocean.common.RequestMethod;
+import java.util.Map;
 
 /**
  * Represents DigitalOcean API Request details
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class ApiRequest {
@@ -47,16 +44,14 @@ public class ApiRequest {
 
   private Integer perPage;
 
-  /**
-   * Default Constructor
-   */
+  /** Default Constructor */
   public ApiRequest() {
     // Default Constructor
   }
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    */
   public ApiRequest(ApiAction apiAction) {
@@ -65,7 +60,7 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param pathParams a api request path variable value(s)
    */
@@ -75,7 +70,7 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param pageNo of the request pagination
    * @param perPage no. of items per page
@@ -86,20 +81,20 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param pageNo of the request pagination
    * @param queryParams of the api request
    * @param perPage no. of items per page
    */
-  public ApiRequest(ApiAction apiAction, Integer pageNo, Map<String, String> queryParams,
-      Integer perPage) {
+  public ApiRequest(
+      ApiAction apiAction, Integer pageNo, Map<String, String> queryParams, Integer perPage) {
     this(apiAction, null, null, pageNo, queryParams, perPage);
   }
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param data a api request body data object
    */
@@ -109,7 +104,7 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param pathParams a api request path variable value(s)
    * @param pageNo of the request pagination
@@ -121,7 +116,7 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param data a api request body data object
    * @param pathParams a api request path variable value(s)
@@ -132,7 +127,7 @@ public class ApiRequest {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param data a api request body data object
    * @param pathParams a api request path variable value(s)
@@ -140,8 +135,13 @@ public class ApiRequest {
    * @param queryParams of the api request
    * @param perPage no. of items per page
    */
-  public ApiRequest(ApiAction apiAction, Object data, Object[] pathParams, Integer pageNo,
-      Map<String, String> queryParams, Integer perPage) {
+  public ApiRequest(
+      ApiAction apiAction,
+      Object data,
+      Object[] pathParams,
+      Integer pageNo,
+      Map<String, String> queryParams,
+      Integer perPage) {
     this.apiAction = apiAction;
     this.data = data;
     this.pathParams = pathParams;
@@ -154,114 +154,82 @@ public class ApiRequest {
     return getElementName().endsWith("s");
   }
 
-  /**
-   * @return the path
-   */
+  /** @return the path */
   public String getPath() {
     return apiAction.getPath();
   }
 
-  /**
-   * @return the elementName
-   */
+  /** @return the elementName */
   public String getElementName() {
     return apiAction.getElementName();
   }
 
-  /**
-   * @return the method
-   */
+  /** @return the method */
   public RequestMethod getMethod() {
     return apiAction.getMethod();
   }
 
-  /**
-   * @return the clazz
-   */
+  /** @return the clazz */
   public Class<?> getClazz() {
     return apiAction.getClazz();
   }
 
-  /**
-   * @return the apiAction
-   */
+  /** @return the apiAction */
   public ApiAction getApiAction() {
     return apiAction;
   }
 
-  /**
-   * @param apiAction the apiAction to set
-   */
+  /** @param apiAction the apiAction to set */
   public void setApiAction(ApiAction apiAction) {
     this.apiAction = apiAction;
   }
 
-  /**
-   * @return the data
-   */
+  /** @return the data */
   public Object getData() {
     return data;
   }
 
-  /**
-   * @param data the data to set
-   */
+  /** @param data the data to set */
   public void setData(Object data) {
     this.data = data;
   }
 
-  /**
-   * @return the pathParams
-   */
+  /** @return the pathParams */
   public Object[] getPathParams() {
     return pathParams;
   }
 
-  /**
-   * @param pathParams the pathParams to set
-   */
+  /** @param pathParams the pathParams to set */
   public void setPathParams(Object[] pathParams) {
     this.pathParams = pathParams;
   }
 
-  /**
-   * @return the queryParams
-   */
+  /** @return the queryParams */
   public Map<String, String> getQueryParams() {
     return queryParams;
   }
 
-  /**
-   * @param queryParams the queryParams to set
-   */
+  /** @param queryParams the queryParams to set */
   public void setQueryParams(Map<String, String> queryParams) {
     this.queryParams = queryParams;
   }
 
-  /**
-   * @return the pageNo
-   */
+  /** @return the pageNo */
   public Integer getPageNo() {
     return pageNo;
   }
 
-  /**
-   * @param pageNo the pageNo to set
-   */
+  /** @param pageNo the pageNo to set */
   public void setPageNo(Integer pageNo) {
     this.pageNo = pageNo;
   }
 
-  /**
-   * @return the perPage
-   */
+  /** @return the perPage */
   public Integer getPerPage() {
     return perPage;
   }
 
-  /**
-   * @param perPage the perPage to set
-   */
+  /** @param perPage the perPage to set */
   public void setPerPage(Integer perPage) {
     this.perPage = perPage;
   }

--- a/src/main/java/com/myjeeva/digitalocean/impl/ApiResponse.java
+++ b/src/main/java/com/myjeeva/digitalocean/impl/ApiResponse.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.impl;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.myjeeva.digitalocean.common.ApiAction;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents DigitalOcean API Response details
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class ApiResponse {
@@ -40,16 +37,14 @@ public class ApiResponse {
 
   private boolean requestSuccess;
 
-  /**
-   * Default Constructor
-   */
+  /** Default Constructor */
   public ApiResponse() {
     // Default constructor
   }
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param requestSuccess result of the executed api request
    */
@@ -59,7 +54,7 @@ public class ApiResponse {
 
   /**
    * Constructor
-   * 
+   *
    * @param apiAction a info about api request
    * @param data a api response object
    * @param requestSuccess result of the executed api request
@@ -79,44 +74,32 @@ public class ApiResponse {
     return (null == data);
   }
 
-  /**
-   * @return the apiAction
-   */
+  /** @return the apiAction */
   public ApiAction getApiAction() {
     return apiAction;
   }
 
-  /**
-   * @param apiAction the apiAction to set
-   */
+  /** @param apiAction the apiAction to set */
   public void setApiAction(ApiAction apiAction) {
     this.apiAction = apiAction;
   }
 
-  /**
-   * @return the data
-   */
+  /** @return the data */
   public Object getData() {
     return data;
   }
 
-  /**
-   * @param data the data to set
-   */
+  /** @param data the data to set */
   public void setData(Object data) {
     this.data = data;
   }
 
-  /**
-   * @return the requestSuccess
-   */
+  /** @return the requestSuccess */
   public boolean isRequestSuccess() {
     return requestSuccess;
   }
 
-  /**
-   * @param requestSuccess the requestSuccess to set
-   */
+  /** @param requestSuccess the requestSuccess to set */
   public void setRequestSuccess(boolean requestSuccess) {
     this.requestSuccess = requestSuccess;
   }

--- a/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
+++ b/src/main/java/com/myjeeva/digitalocean/impl/DigitalOceanClient.java
@@ -1,58 +1,24 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.impl;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.ParseException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -114,59 +80,74 @@ import com.myjeeva.digitalocean.serializer.DropletSerializer;
 import com.myjeeva.digitalocean.serializer.FirewallSerializer;
 import com.myjeeva.digitalocean.serializer.LoadBalancerSerializer;
 import com.myjeeva.digitalocean.serializer.VolumeSerializer;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.ParseException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * DigitalOcean API client wrapper methods Implementation
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class DigitalOceanClient implements DigitalOcean, Constants {
 
   private static final Logger log = LoggerFactory.getLogger(DigitalOceanClient.class);
 
-  /**
-   * Http client
-   */
+  /** Http client */
   protected CloseableHttpClient httpClient;
 
-  /**
-   * OAuth Authorization Token for Accessing DigitalOcean API
-   */
+  /** OAuth Authorization Token for Accessing DigitalOcean API */
   protected String authToken;
 
-  /**
-   * DigitalOcean API version. defaults to v2 from constructor
-   */
+  /** DigitalOcean API version. defaults to v2 from constructor */
   protected String apiVersion;
 
-  /**
-   * DigitalOcean API Host is <code>api.digitalocean.com</code>
-   */
+  /** DigitalOcean API Host is <code>api.digitalocean.com</code> */
   protected String apiHost = "api.digitalocean.com";
 
-  /**
-   * Gson Parser instance for deserialize
-   */
+  /** Gson Parser instance for deserialize */
   private Gson deserialize;
 
-  /**
-   * Gson Parser instance for serialize
-   */
+  /** Gson Parser instance for serialize */
   private Gson serialize;
 
-  /**
-   * JSON Parser instance
-   */
+  /** JSON Parser instance */
   private JsonParser jsonParser;
 
-  /**
-   * API Request Header
-   */
+  /** API Request Header */
   private Header[] requestHeaders;
 
   /**
    * DigitalOcean Client Constructor
-   * 
+   *
    * @param authToken a {@link String} object
    */
   public DigitalOceanClient(String authToken) {
@@ -175,7 +156,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
   /**
    * DigitalOcean Client Constructor
-   * 
+   *
    * @param apiVersion a {@link String} object
    * @param authToken a {@link String} object
    */
@@ -185,7 +166,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
   /**
    * DigitalOcean Client Constructor
-   * 
+   *
    * @param apiVersion a {@link String} object
    * @param authToken a {@link String} object
    * @param httpClient a {@link CloseableHttpClient} object
@@ -202,44 +183,32 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     initialize();
   }
 
-  /**
-   * @return the httpClient
-   */
+  /** @return the httpClient */
   public HttpClient getHttpClient() {
     return httpClient;
   }
 
-  /**
-   * @param httpClient the httpClient to set
-   */
+  /** @param httpClient the httpClient to set */
   public void setHttpClient(CloseableHttpClient httpClient) {
     this.httpClient = httpClient;
   }
 
-  /**
-   * @return the authToken
-   */
+  /** @return the authToken */
   public String getAuthToken() {
     return authToken;
   }
 
-  /**
-   * @param authToken the authToken to set
-   */
+  /** @param authToken the authToken to set */
   public void setAuthToken(String authToken) {
     this.authToken = authToken;
   }
 
-  /**
-   * @return the apiVersion
-   */
+  /** @return the apiVersion */
   public String getApiVersion() {
     return apiVersion;
   }
 
-  /**
-   * @param apiVersion the apiVersion to set
-   */
+  /** @param apiVersion the apiVersion to set */
   public void setApiVersion(String apiVersion) {
     this.apiVersion = apiVersion;
   }
@@ -253,8 +222,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
 
-    return (Droplets) perform(new ApiRequest(ApiAction.AVAILABLE_DROPLETS, pageNo, perPage))
-        .getData();
+    return (Droplets)
+        perform(new ApiRequest(ApiAction.AVAILABLE_DROPLETS, pageNo, perPage)).getData();
   }
 
   @Override
@@ -263,8 +232,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletIdAndPageNo(dropletId, pageNo);
 
     Object[] params = {dropletId};
-    return (Kernels) perform(
-        new ApiRequest(ApiAction.GET_DROPLETS_KERNELS, params, pageNo, perPage)).getData();
+    return (Kernels)
+        perform(new ApiRequest(ApiAction.GET_DROPLETS_KERNELS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -273,8 +242,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletIdAndPageNo(dropletId, pageNo);
 
     Object[] params = {dropletId};
-    return (Snapshots) perform(
-        new ApiRequest(ApiAction.GET_DROPLET_SNAPSHOTS, params, pageNo, perPage)).getData();
+    return (Snapshots)
+        perform(new ApiRequest(ApiAction.GET_DROPLET_SNAPSHOTS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -283,8 +252,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletIdAndPageNo(dropletId, pageNo);
 
     Object[] params = {dropletId};
-    return (Backups) perform(new ApiRequest(ApiAction.GET_DROPLET_BACKUPS, params, pageNo, perPage))
-        .getData();
+    return (Backups)
+        perform(new ApiRequest(ApiAction.GET_DROPLET_BACKUPS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -299,8 +268,11 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Droplet createDroplet(Droplet droplet)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == droplet || StringUtils.isBlank(droplet.getName()) || null == droplet.getRegion()
-        || null == droplet.getSize() || (null == droplet.getImage()
+    if (null == droplet
+        || StringUtils.isBlank(droplet.getName())
+        || null == droplet.getRegion()
+        || null == droplet.getSize()
+        || (null == droplet.getImage()
             || (null == droplet.getImage().getId() && null == droplet.getImage().getSlug()))) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Region Slug, Size Slug, Image Id/Slug] for create droplet.");
@@ -312,8 +284,11 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Droplets createDroplets(Droplet droplet)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == droplet || (null == droplet.getNames() || droplet.getNames().isEmpty())
-        || null == droplet.getRegion() || null == droplet.getSize() || (null == droplet.getImage()
+    if (null == droplet
+        || (null == droplet.getNames() || droplet.getNames().isEmpty())
+        || null == droplet.getRegion()
+        || null == droplet.getSize()
+        || (null == droplet.getImage()
             || (null == droplet.getImage().getId() && null == droplet.getImage().getSlug()))) {
       throw new IllegalArgumentException(
           "Missing required parameters [Names, Region Slug, Size Slug, Image Id/Slug] for creating multiple droplets.");
@@ -343,8 +318,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
     Map<String, String> queryParams = new HashMap<String, String>();
     queryParams.put("tag_name", tagName);
-    return (Delete) perform(
-        new ApiRequest(ApiAction.DELETE_DROPLET_BY_TAG_NAME, null, queryParams, null)).getData();
+    return (Delete)
+        perform(new ApiRequest(ApiAction.DELETE_DROPLET_BY_TAG_NAME, null, queryParams, null))
+            .getData();
   }
 
   @Override
@@ -353,8 +329,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletIdAndPageNo(dropletId, pageNo);
 
     Object[] params = {dropletId};
-    return (Droplets) perform(new ApiRequest(ApiAction.GET_DROPLET_NEIGHBORS, params, pageNo, null))
-        .getData();
+    return (Droplets)
+        perform(new ApiRequest(ApiAction.GET_DROPLET_NEIGHBORS, params, pageNo, null)).getData();
   }
 
   @Override
@@ -374,8 +350,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Map<String, String> queryParams = new HashMap<String, String>();
     queryParams.put("tag_name", tagName);
 
-    return (Droplets) perform(
-        new ApiRequest(ApiAction.AVAILABLE_DROPLETS, pageNo, queryParams, perPage)).getData();
+    return (Droplets)
+        perform(new ApiRequest(ApiAction.AVAILABLE_DROPLETS, pageNo, queryParams, perPage))
+            .getData();
   }
 
   // Droplet action methods
@@ -386,8 +363,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(
-        new ApiRequest(ApiAction.REBOOT_DROPLET, new DropletAction(ActionType.REBOOT), params))
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.REBOOT_DROPLET, new DropletAction(ActionType.REBOOT), params))
             .getData();
   }
 
@@ -397,8 +376,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.POWER_CYCLE_DROPLET,
-        new DropletAction(ActionType.POWER_CYCLE), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.POWER_CYCLE_DROPLET,
+                    new DropletAction(ActionType.POWER_CYCLE),
+                    params))
+            .getData();
   }
 
   @Override
@@ -407,8 +391,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(
-        new ApiRequest(ApiAction.SHUTDOWN_DROPLET, new DropletAction(ActionType.SHUTDOWN), params))
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.SHUTDOWN_DROPLET, new DropletAction(ActionType.SHUTDOWN), params))
             .getData();
   }
 
@@ -418,8 +404,11 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.POWER_OFF_DROPLET,
-        new DropletAction(ActionType.POWER_OFF), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.POWER_OFF_DROPLET, new DropletAction(ActionType.POWER_OFF), params))
+            .getData();
   }
 
   @Override
@@ -428,8 +417,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(
-        new ApiRequest(ApiAction.POWER_ON_DROPLET, new DropletAction(ActionType.POWER_ON), params))
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.POWER_ON_DROPLET, new DropletAction(ActionType.POWER_ON), params))
             .getData();
   }
 
@@ -439,8 +430,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.RESET_DROPLET_PASSWORD,
-        new DropletAction(ActionType.PASSWORD_RESET), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.RESET_DROPLET_PASSWORD,
+                    new DropletAction(ActionType.PASSWORD_RESET),
+                    params))
+            .getData();
   }
 
   @Override
@@ -472,8 +468,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(
-        new ApiRequest(ApiAction.SNAPSHOT_DROPLET, new DropletAction(ActionType.SNAPSHOT), params))
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.SNAPSHOT_DROPLET, new DropletAction(ActionType.SNAPSHOT), params))
             .getData();
   }
 
@@ -516,8 +514,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.ENABLE_DROPLET_BACKUPS,
-        new DropletAction(ActionType.ENABLE_BACKUPS), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ENABLE_DROPLET_BACKUPS,
+                    new DropletAction(ActionType.ENABLE_BACKUPS),
+                    params))
+            .getData();
   }
 
   @Override
@@ -526,8 +529,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.DISABLE_DROPLET_BACKUPS,
-        new DropletAction(ActionType.DISABLE_BACKUPS), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.DISABLE_DROPLET_BACKUPS,
+                    new DropletAction(ActionType.DISABLE_BACKUPS),
+                    params))
+            .getData();
   }
 
   @Override
@@ -549,8 +557,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {dropletId};
     DropletAction action = new DropletAction(ActionType.CHANGE_KERNEL);
     action.setKernel(kernelId);
-    return (Action) perform(new ApiRequest(ApiAction.CHANGE_DROPLET_KERNEL, action, params))
-        .getData();
+    return (Action)
+        perform(new ApiRequest(ApiAction.CHANGE_DROPLET_KERNEL, action, params)).getData();
   }
 
   @Override
@@ -559,8 +567,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.ENABLE_DROPLET_IPV6,
-        new DropletAction(ActionType.ENABLE_IPV6), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ENABLE_DROPLET_IPV6,
+                    new DropletAction(ActionType.ENABLE_IPV6),
+                    params))
+            .getData();
   }
 
   @Override
@@ -569,8 +582,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletId(dropletId);
 
     Object[] params = {dropletId};
-    return (Action) perform(new ApiRequest(ApiAction.ENABLE_DROPLET_PRIVATE_NETWORKING,
-        new DropletAction(ActionType.ENABLE_PRIVATE_NETWORKING), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ENABLE_DROPLET_PRIVATE_NETWORKING,
+                    new DropletAction(ActionType.ENABLE_PRIVATE_NETWORKING),
+                    params))
+            .getData();
   }
 
   // ==============================================
@@ -590,8 +608,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   public Actions getAvailableActions(Integer pageNo, Integer perPage)
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
-    return (Actions) perform(new ApiRequest(ApiAction.AVAILABLE_ACTIONS, pageNo, perPage))
-        .getData();
+    return (Actions)
+        perform(new ApiRequest(ApiAction.AVAILABLE_ACTIONS, pageNo, perPage)).getData();
   }
 
   @Override
@@ -609,8 +627,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateDropletIdAndPageNo(dropletId, pageNo);
 
     Object[] params = {dropletId};
-    return (Actions) perform(new ApiRequest(ApiAction.GET_DROPLET_ACTIONS, params, pageNo, perPage))
-        .getData();
+    return (Actions)
+        perform(new ApiRequest(ApiAction.GET_DROPLET_ACTIONS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -620,8 +638,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validatePageNo(pageNo);
 
     Object[] params = {imageId};
-    return (Actions) perform(new ApiRequest(ApiAction.GET_IMAGE_ACTIONS, params, pageNo, perPage))
-        .getData();
+    return (Actions)
+        perform(new ApiRequest(ApiAction.GET_IMAGE_ACTIONS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -631,8 +649,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validatePageNo(pageNo);
 
     Object[] params = {ipAddress};
-    return (Actions) perform(
-        new ApiRequest(ApiAction.GET_FLOATING_IP_ACTIONS, params, pageNo, perPage)).getData();
+    return (Actions)
+        perform(new ApiRequest(ApiAction.GET_FLOATING_IP_ACTIONS, params, pageNo, perPage))
+            .getData();
   }
 
   @Override
@@ -642,8 +661,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkNullAndThrowError(actionId, "Missing required parameter - actionId.");
 
     Object[] params = {ipAddress, actionId};
-    return (Action) perform(new ApiRequest(ApiAction.GET_FLOATING_IP_ACTION_INFO, params))
-        .getData();
+    return (Action)
+        perform(new ApiRequest(ApiAction.GET_FLOATING_IP_ACTION_INFO, params)).getData();
   }
 
   @Override
@@ -690,8 +709,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
           "Incorrect type value [Allowed: DISTRIBUTION or APPLICATION].");
     }
 
-    return (Images) perform(new ApiRequest(ApiAction.AVAILABLE_IMAGES, pageNo, qp, perPage))
-        .getData();
+    return (Images)
+        perform(new ApiRequest(ApiAction.AVAILABLE_IMAGES, pageNo, qp, perPage)).getData();
   }
 
   @Override
@@ -700,8 +719,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validatePageNo(pageNo);
     Map<String, String> qp = new HashMap<String, String>();
     qp.put("private", "true");
-    return (Images) perform(new ApiRequest(ApiAction.AVAILABLE_IMAGES, pageNo, qp, perPage))
-        .getData();
+    return (Images)
+        perform(new ApiRequest(ApiAction.AVAILABLE_IMAGES, pageNo, qp, perPage)).getData();
   }
 
   @Override
@@ -725,7 +744,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Image createCustomImage(Image image)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == image || StringUtils.isBlank(image.getName()) || StringUtils.isBlank(image.getUrl())
+    if (null == image
+        || StringUtils.isBlank(image.getName())
+        || StringUtils.isBlank(image.getUrl())
         || StringUtils.isBlank(image.getRegion())) {
       throw new IllegalArgumentException(
           "Missing required parameter to create custom image [name, url, or region].");
@@ -760,8 +781,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(regionSlug, "Missing required parameter - regionSlug.");
 
     Object[] params = {imageId};
-    return (Action) perform(new ApiRequest(ApiAction.TRANSFER_IMAGE,
-        new ImageAction(ActionType.TRANSFER, regionSlug), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.TRANSFER_IMAGE,
+                    new ImageAction(ActionType.TRANSFER, regionSlug),
+                    params))
+            .getData();
   }
 
   @Override
@@ -770,8 +796,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkNullAndThrowError(imageId, "Missing required parameter - imageId.");
 
     Object[] params = {imageId};
-    return (Action) perform(
-        new ApiRequest(ApiAction.CONVERT_IMAGE, new ImageAction(ActionType.CONVERT), params))
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.CONVERT_IMAGE, new ImageAction(ActionType.CONVERT), params))
             .getData();
   }
 
@@ -783,8 +811,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   public Regions getAvailableRegions(Integer pageNo)
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
-    return (Regions) perform(new ApiRequest(ApiAction.AVAILABLE_REGIONS, pageNo, DEFAULT_PAGE_SIZE))
-        .getData();
+    return (Regions)
+        perform(new ApiRequest(ApiAction.AVAILABLE_REGIONS, pageNo, DEFAULT_PAGE_SIZE)).getData();
   }
 
   // =======================================
@@ -795,8 +823,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   public Sizes getAvailableSizes(Integer pageNo)
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
-    return (Sizes) perform(new ApiRequest(ApiAction.AVAILABLE_SIZES, pageNo, DEFAULT_PAGE_SIZE))
-        .getData();
+    return (Sizes)
+        perform(new ApiRequest(ApiAction.AVAILABLE_SIZES, pageNo, DEFAULT_PAGE_SIZE)).getData();
   }
 
   // =======================================
@@ -806,8 +834,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Domains getAvailableDomains(Integer pageNo)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    return (Domains) perform(new ApiRequest(ApiAction.AVAILABLE_DOMAINS, pageNo, DEFAULT_PAGE_SIZE))
-        .getData();
+    return (Domains)
+        perform(new ApiRequest(ApiAction.AVAILABLE_DOMAINS, pageNo, DEFAULT_PAGE_SIZE)).getData();
   }
 
   @Override
@@ -845,8 +873,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(domainName, "Missing required parameter - domainName.");
 
     Object[] params = {domainName};
-    return (DomainRecords) perform(
-        new ApiRequest(ApiAction.GET_DOMAIN_RECORDS, params, pageNo, perPage)).getData();
+    return (DomainRecords)
+        perform(new ApiRequest(ApiAction.GET_DOMAIN_RECORDS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -856,8 +884,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkNullAndThrowError(recordId, "Missing required parameter - recordId.");
 
     Object[] params = {domainName, recordId};
-    return (DomainRecord) perform(new ApiRequest(ApiAction.GET_DOMAIN_RECORD_INFO, params))
-        .getData();
+    return (DomainRecord)
+        perform(new ApiRequest(ApiAction.GET_DOMAIN_RECORD_INFO, params)).getData();
   }
 
   @Override
@@ -867,20 +895,21 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkNullAndThrowError(domainRecord, "Missing required parameter - domainRecord");
 
     Object[] params = {domainName};
-    return (DomainRecord) perform(
-        new ApiRequest(ApiAction.CREATE_DOMAIN_RECORD, domainRecord, params)).getData();
+    return (DomainRecord)
+        perform(new ApiRequest(ApiAction.CREATE_DOMAIN_RECORD, domainRecord, params)).getData();
   }
 
   @Override
-  public DomainRecord updateDomainRecord(String domainName, Integer recordId,
-      DomainRecord domainRecord) throws DigitalOceanException, RequestUnsuccessfulException {
+  public DomainRecord updateDomainRecord(
+      String domainName, Integer recordId, DomainRecord domainRecord)
+      throws DigitalOceanException, RequestUnsuccessfulException {
     checkBlankAndThrowError(domainName, "Missing required parameter - domainName.");
     checkNullAndThrowError(recordId, "Missing required parameter - recordId.");
     checkNullAndThrowError(domainRecord, "Missing required parameter - domainRecord");
 
     Object[] params = {domainName, recordId};
-    return (DomainRecord) perform(
-        new ApiRequest(ApiAction.UPDATE_DOMAIN_RECORD, domainRecord, params)).getData();
+    return (DomainRecord)
+        perform(new ApiRequest(ApiAction.UPDATE_DOMAIN_RECORD, domainRecord, params)).getData();
   }
 
   @Override
@@ -896,8 +925,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Keys getAvailableKeys(Integer pageNo)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    return (Keys) perform(new ApiRequest(ApiAction.AVAILABLE_KEYS, pageNo, DEFAULT_PAGE_SIZE))
-        .getData();
+    return (Keys)
+        perform(new ApiRequest(ApiAction.AVAILABLE_KEYS, pageNo, DEFAULT_PAGE_SIZE)).getData();
   }
 
   @Override
@@ -934,8 +963,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(newSshKeyName, "Missing required parameter - newSshKeyName.");
 
     Object[] params = {sshKeyId};
-    return (Key) perform(new ApiRequest(ApiAction.UPDATE_KEY, new Key(newSshKeyName), params))
-        .getData();
+    return (Key)
+        perform(new ApiRequest(ApiAction.UPDATE_KEY, new Key(newSshKeyName), params)).getData();
   }
 
   @Override
@@ -945,8 +974,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(newSshKeyName, "Missing required parameter - newSshKeyName.");
 
     Object[] params = {fingerprint};
-    return (Key) perform(new ApiRequest(ApiAction.UPDATE_KEY, new Key(newSshKeyName), params))
-        .getData();
+    return (Key)
+        perform(new ApiRequest(ApiAction.UPDATE_KEY, new Key(newSshKeyName), params)).getData();
   }
 
   @Override
@@ -984,8 +1013,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validateDropletId(dropletId);
 
-    return (FloatingIP) perform(
-        new ApiRequest(ApiAction.CREATE_FLOATING_IP, new FloatingIPAction(dropletId))).getData();
+    return (FloatingIP)
+        perform(new ApiRequest(ApiAction.CREATE_FLOATING_IP, new FloatingIPAction(dropletId)))
+            .getData();
   }
 
   @Override
@@ -993,8 +1023,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     checkBlankAndThrowError(region, "Missing required parameter - region.");
 
-    return (FloatingIP) perform(
-        new ApiRequest(ApiAction.CREATE_FLOATING_IP, new FloatingIPAction(region))).getData();
+    return (FloatingIP)
+        perform(new ApiRequest(ApiAction.CREATE_FLOATING_IP, new FloatingIPAction(region)))
+            .getData();
   }
 
   @Override
@@ -1022,8 +1053,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(ipAddress, "Missing required parameter - ipAddress.");
 
     Object[] params = {ipAddress};
-    return (Action) perform(new ApiRequest(ApiAction.ASSIGN_FLOATING_IP,
-        new FloatingIPAction(dropletId, "assign"), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ASSIGN_FLOATING_IP,
+                    new FloatingIPAction(dropletId, "assign"),
+                    params))
+            .getData();
   }
 
   @Override
@@ -1032,8 +1068,11 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(ipAddress, "Missing required parameter - ipAddress.");
 
     Object[] params = {ipAddress};
-    return (Action) perform(new ApiRequest(ApiAction.UNASSIGN_FLOATING_IP,
-        new FloatingIPAction(null, "unassign"), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.UNASSIGN_FLOATING_IP, new FloatingIPAction(null, "unassign"), params))
+            .getData();
   }
 
   // =======================================
@@ -1080,8 +1119,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     }
 
     Object[] params = {name};
-    return (Response) perform(
-        new ApiRequest(ApiAction.TAG_RESOURCE, new Resources(resources), params)).getData();
+    return (Response)
+        perform(new ApiRequest(ApiAction.TAG_RESOURCE, new Resources(resources), params)).getData();
   }
 
   @Override
@@ -1094,8 +1133,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     }
 
     Object[] params = {name};
-    return (Response) perform(
-        new ApiRequest(ApiAction.UNTAG_RESOURCE, new Resources(resources), params)).getData();
+    return (Response)
+        perform(new ApiRequest(ApiAction.UNTAG_RESOURCE, new Resources(resources), params))
+            .getData();
   }
 
   // =======================================
@@ -1115,7 +1155,9 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Volume createVolume(Volume volume)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == volume || StringUtils.isBlank(volume.getName()) || null == volume.getRegion()
+    if (null == volume
+        || StringUtils.isBlank(volume.getName())
+        || null == volume.getRegion()
         || null == volume.getSize()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Region Slug, Size] for create volume.");
@@ -1174,8 +1216,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(regionSlug, "Missing required parameter - regionSlug.");
 
     Object[] params = {volumeId};
-    return (Action) perform(new ApiRequest(ApiAction.ACTIONS_VOLUME,
-        new VolumeAction(ActionType.ATTACH, dropletId, regionSlug), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ACTIONS_VOLUME,
+                    new VolumeAction(ActionType.ATTACH, dropletId, regionSlug),
+                    params))
+            .getData();
   }
 
   @Override
@@ -1185,8 +1232,12 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(volumeName, "Missing required parameter - volumeName.");
     checkBlankAndThrowError(regionSlug, "Missing required parameter - regionSlug.");
 
-    return (Action) perform(new ApiRequest(ApiAction.ACTIONS_VOLUME_BY_NAME,
-        new VolumeAction(ActionType.ATTACH, dropletId, regionSlug, volumeName, null))).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ACTIONS_VOLUME_BY_NAME,
+                    new VolumeAction(ActionType.ATTACH, dropletId, regionSlug, volumeName, null)))
+            .getData();
   }
 
   @Override
@@ -1197,8 +1248,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(regionSlug, "Missing required parameter - regionSlug.");
 
     Object[] params = {volumeId};
-    return (Action) perform(new ApiRequest(ApiAction.ACTIONS_VOLUME,
-        new VolumeAction(ActionType.DETACH, dropletId, regionSlug), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ACTIONS_VOLUME,
+                    new VolumeAction(ActionType.DETACH, dropletId, regionSlug),
+                    params))
+            .getData();
   }
 
   @Override
@@ -1208,8 +1264,12 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(volumeName, "Missing required parameter - volumeName.");
     checkBlankAndThrowError(regionSlug, "Missing required parameter - regionSlug.");
 
-    return (Action) perform(new ApiRequest(ApiAction.ACTIONS_VOLUME_BY_NAME,
-        new VolumeAction(ActionType.DETACH, dropletId, regionSlug, volumeName, null))).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ACTIONS_VOLUME_BY_NAME,
+                    new VolumeAction(ActionType.DETACH, dropletId, regionSlug, volumeName, null)))
+            .getData();
   }
 
   @Override
@@ -1223,8 +1283,13 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     }
 
     Object[] params = {volumeId};
-    return (Action) perform(new ApiRequest(ApiAction.ACTIONS_VOLUME,
-        new VolumeAction(ActionType.RESIZE, regionSlug, sizeGigabytes), params)).getData();
+    return (Action)
+        perform(
+                new ApiRequest(
+                    ApiAction.ACTIONS_VOLUME,
+                    new VolumeAction(ActionType.RESIZE, regionSlug, sizeGigabytes),
+                    params))
+            .getData();
   }
 
   @Override
@@ -1234,8 +1299,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     checkBlankAndThrowError(volumeId, "Missing required parameter - volumeId.");
 
     Object[] params = {volumeId};
-    return (Snapshots) perform(
-        new ApiRequest(ApiAction.GET_VOLUME_SNAPSHOTS, params, pageNo, perPage)).getData();
+    return (Snapshots)
+        perform(new ApiRequest(ApiAction.GET_VOLUME_SNAPSHOTS, params, pageNo, perPage)).getData();
   }
 
   @Override
@@ -1260,8 +1325,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
 
-    return (Snapshots) perform(new ApiRequest(ApiAction.AVAILABLE_SNAPSHOTS, pageNo, perPage))
-        .getData();
+    return (Snapshots)
+        perform(new ApiRequest(ApiAction.AVAILABLE_SNAPSHOTS, pageNo, perPage)).getData();
   }
 
   @Override
@@ -1272,8 +1337,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Map<String, String> qp = new HashMap<String, String>();
     qp.put("resource_type", "droplet");
 
-    return (Snapshots) perform(new ApiRequest(ApiAction.ALL_DROPLET_SNAPSHOTS, pageNo, qp, perPage))
-        .getData();
+    return (Snapshots)
+        perform(new ApiRequest(ApiAction.ALL_DROPLET_SNAPSHOTS, pageNo, qp, perPage)).getData();
   }
 
   @Override
@@ -1284,8 +1349,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Map<String, String> qp = new HashMap<String, String>();
     qp.put("resource_type", "volume");
 
-    return (Snapshots) perform(new ApiRequest(ApiAction.ALL_VOLUME_SNAPSHOTS, pageNo, qp, perPage))
-        .getData();
+    return (Snapshots)
+        perform(new ApiRequest(ApiAction.ALL_VOLUME_SNAPSHOTS, pageNo, qp, perPage)).getData();
   }
 
   @Override
@@ -1313,7 +1378,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public LoadBalancer createLoadBalancer(LoadBalancer loadBalancer)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == loadBalancer || StringUtils.isBlank(loadBalancer.getName())
+    if (null == loadBalancer
+        || StringUtils.isBlank(loadBalancer.getName())
         || null == loadBalancer.getRegion()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Region Slug] for create loadBalancer.");
@@ -1321,8 +1387,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateForwardingRules(loadBalancer.getForwardingRules());
     validateHealthCheck(loadBalancer.getHealthCheck());
 
-    return (LoadBalancer) perform(new ApiRequest(ApiAction.CREATE_LOAD_BALANCER, loadBalancer))
-        .getData();
+    return (LoadBalancer)
+        perform(new ApiRequest(ApiAction.CREATE_LOAD_BALANCER, loadBalancer)).getData();
   }
 
   @Override
@@ -1331,8 +1397,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     validateLoadBalancerId(loadBalancerId);
 
     Object[] params = {loadBalancerId};
-    return (LoadBalancer) perform(new ApiRequest(ApiAction.GET_LOAD_BALANCER_INFO, params))
-        .getData();
+    return (LoadBalancer)
+        perform(new ApiRequest(ApiAction.GET_LOAD_BALANCER_INFO, params)).getData();
   }
 
   @Override
@@ -1340,15 +1406,17 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
 
-    return (LoadBalancers) perform(
-        new ApiRequest(ApiAction.AVAILABLE_LOAD_BALANCERS, pageNo, perPage)).getData();
+    return (LoadBalancers)
+        perform(new ApiRequest(ApiAction.AVAILABLE_LOAD_BALANCERS, pageNo, perPage)).getData();
   }
 
   @Override
   public LoadBalancer updateLoadBalancer(LoadBalancer loadBalancer)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == loadBalancer || StringUtils.isBlank(loadBalancer.getId())
-        || StringUtils.isBlank(loadBalancer.getName()) || null == loadBalancer.getRegion()) {
+    if (null == loadBalancer
+        || StringUtils.isBlank(loadBalancer.getId())
+        || StringUtils.isBlank(loadBalancer.getName())
+        || null == loadBalancer.getRegion()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Id, Name, Region Slug] for update loadBalancer.");
     }
@@ -1357,8 +1425,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
 
     Object[] params = {loadBalancer.getId()};
 
-    return (LoadBalancer) perform(
-        new ApiRequest(ApiAction.UPDATE_LOAD_BALANCER, loadBalancer, params)).getData();
+    return (LoadBalancer)
+        perform(new ApiRequest(ApiAction.UPDATE_LOAD_BALANCER, loadBalancer, params)).getData();
   }
 
   @Override
@@ -1373,8 +1441,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {loadBalancerId};
     Map<String, List<Integer>> data = new HashMap<>();
     data.put("droplet_ids", dropletIds);
-    return (Response) perform(new ApiRequest(ApiAction.ADD_DROPLET_TO_LOAD_BALANCER, data, params))
-        .getData();
+    return (Response)
+        perform(new ApiRequest(ApiAction.ADD_DROPLET_TO_LOAD_BALANCER, data, params)).getData();
   }
 
   @Override
@@ -1389,13 +1457,14 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {loadBalancerId};
     Map<String, List<Integer>> data = new HashMap<>();
     data.put("droplet_ids", dropletIds);
-    return (Delete) perform(
-        new ApiRequest(ApiAction.REMOVE_DROPLET_FROM_LOAD_BALANCER, data, params)).getData();
+    return (Delete)
+        perform(new ApiRequest(ApiAction.REMOVE_DROPLET_FROM_LOAD_BALANCER, data, params))
+            .getData();
   }
 
   @Override
-  public Response addForwardingRulesToLoadBalancer(String loadBalancerId,
-      List<ForwardingRules> forwardingRules)
+  public Response addForwardingRulesToLoadBalancer(
+      String loadBalancerId, List<ForwardingRules> forwardingRules)
       throws DigitalOceanException, RequestUnsuccessfulException {
     validateLoadBalancerId(loadBalancerId);
 
@@ -1406,13 +1475,14 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {loadBalancerId};
     Map<String, List<ForwardingRules>> data = new HashMap<>();
     data.put("forwarding_rules", forwardingRules);
-    return (Response) perform(
-        new ApiRequest(ApiAction.ADD_FORWARDING_RULES_TO_LOAD_BALANCER, data, params)).getData();
+    return (Response)
+        perform(new ApiRequest(ApiAction.ADD_FORWARDING_RULES_TO_LOAD_BALANCER, data, params))
+            .getData();
   }
 
   @Override
-  public Delete removeForwardingRulesFromLoadBalancer(String loadBalancerId,
-      List<ForwardingRules> forwardingRules)
+  public Delete removeForwardingRulesFromLoadBalancer(
+      String loadBalancerId, List<ForwardingRules> forwardingRules)
       throws DigitalOceanException, RequestUnsuccessfulException {
     validateLoadBalancerId(loadBalancerId);
 
@@ -1423,8 +1493,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {loadBalancerId};
     Map<String, List<ForwardingRules>> data = new HashMap<>();
     data.put("forwarding_rules", forwardingRules);
-    return (Delete) perform(
-        new ApiRequest(ApiAction.REMOVE_FORWARDING_RULES_FROM_LOAD_BALANCER, data, params))
+    return (Delete)
+        perform(new ApiRequest(ApiAction.REMOVE_FORWARDING_RULES_FROM_LOAD_BALANCER, data, params))
             .getData();
   }
 
@@ -1446,14 +1516,15 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
 
-    return (Certificates) perform(new ApiRequest(ApiAction.AVAILABLE_CERTIFICATES, pageNo, perPage))
-        .getData();
+    return (Certificates)
+        perform(new ApiRequest(ApiAction.AVAILABLE_CERTIFICATES, pageNo, perPage)).getData();
   }
 
   @Override
   public Certificate createCertificate(Certificate certificate)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == certificate || StringUtils.isBlank(certificate.getName())
+    if (null == certificate
+        || StringUtils.isBlank(certificate.getName())
         || StringUtils.isBlank(certificate.getPrivateKey())
         || StringUtils.isBlank(certificate.getLeafCertificate())
         || StringUtils.isBlank(certificate.getCertificateChain())) {
@@ -1461,22 +1532,25 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
           "Missing required parameters [Name, Private Key, Leaf Certificate, Certificate Chain] for create certificate.");
     }
 
-    return (Certificate) perform(new ApiRequest(ApiAction.CREATE_CERTIFICATE, certificate))
-        .getData();
+    return (Certificate)
+        perform(new ApiRequest(ApiAction.CREATE_CERTIFICATE, certificate)).getData();
   }
 
   @Override
   public Certificate createLetsEncryptCertificate(Certificate certificate)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == certificate || StringUtils.isBlank(certificate.getName())
-        || StringUtils.isBlank(certificate.getType()) || certificate.getType() != "lets_encrypt"
-        || certificate.getDnsNames() == null || certificate.getDnsNames().isEmpty()) {
+    if (null == certificate
+        || StringUtils.isBlank(certificate.getName())
+        || StringUtils.isBlank(certificate.getType())
+        || certificate.getType() != "lets_encrypt"
+        || certificate.getDnsNames() == null
+        || certificate.getDnsNames().isEmpty()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Type(lets_encrypt), List of DNS Names] for create Let's Encrypt certificate.");
     }
 
-    return (Certificate) perform(new ApiRequest(ApiAction.CREATE_CERTIFICATE, certificate))
-        .getData();
+    return (Certificate)
+        perform(new ApiRequest(ApiAction.CREATE_CERTIFICATE, certificate)).getData();
   }
 
   @Override
@@ -1496,7 +1570,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {certificateId};
     return (Delete) perform(new ApiRequest(ApiAction.DELETE_CERTIFICATE, params)).getData();
   }
-  
+
   // ===========================================
   // Firewall manipulation methods
   // ===========================================
@@ -1504,8 +1578,10 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Firewall createFirewall(Firewall firewall)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == firewall || StringUtils.isBlank(firewall.getName())
-        || firewall.getInboundRules().isEmpty() || firewall.getOutboundRules().isEmpty()) {
+    if (null == firewall
+        || StringUtils.isBlank(firewall.getName())
+        || firewall.getInboundRules().isEmpty()
+        || firewall.getOutboundRules().isEmpty()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Inbound rules, Outbound rules] for create firewall.");
     }
@@ -1515,8 +1591,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Firewall getFirewallInfo(String firewallId)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    checkBlankAndThrowError(firewallId,
-        "Missing required parameters [FirewallID] for get firewall info.");
+    checkBlankAndThrowError(
+        firewallId, "Missing required parameters [FirewallID] for get firewall info.");
 
     Object[] params = {firewallId};
     return (Firewall) perform(new ApiRequest(ApiAction.GET_FIREWALL_INFO, params)).getData();
@@ -1525,22 +1601,24 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   @Override
   public Firewall updateFirewall(Firewall firewall)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    if (null == firewall || StringUtils.isBlank(firewall.getName())
-        || firewall.getInboundRules().isEmpty() || firewall.getOutboundRules().isEmpty()) {
+    if (null == firewall
+        || StringUtils.isBlank(firewall.getName())
+        || firewall.getInboundRules().isEmpty()
+        || firewall.getOutboundRules().isEmpty()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Name, Inbound rules, Outbound rules] for update firewall info.");
     }
 
     Object[] params = {firewall.getId()};
-    return (Firewall) perform(new ApiRequest(ApiAction.UPDATE_FIREWALL, firewall, params))
-        .getData();
+    return (Firewall)
+        perform(new ApiRequest(ApiAction.UPDATE_FIREWALL, firewall, params)).getData();
   }
 
   @Override
   public Delete deleteFirewall(String firewallId)
       throws DigitalOceanException, RequestUnsuccessfulException {
-    checkBlankAndThrowError(firewallId,
-        "Missing required parameters [ID] for delete firewall info.");
+    checkBlankAndThrowError(
+        firewallId, "Missing required parameters [ID] for delete firewall info.");
 
     Object[] params = {firewallId};
     return (Delete) perform(new ApiRequest(ApiAction.DELETE_FIREWALL, params)).getData();
@@ -1558,8 +1636,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {firewallId};
     Map<String, List<Integer>> data = new HashMap<>();
     data.put("droplet_ids", dropletIds);
-    return (Response) perform(new ApiRequest(ApiAction.ADD_DROPLET_TO_FIREWALL, data, params))
-        .getData();
+    return (Response)
+        perform(new ApiRequest(ApiAction.ADD_DROPLET_TO_FIREWALL, data, params)).getData();
   }
 
   @Override
@@ -1574,8 +1652,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     Object[] params = {firewallId};
     Map<String, List<Integer>> data = new HashMap<>();
     data.put("droplet_ids", dropletIds);
-    return (Delete) perform(new ApiRequest(ApiAction.REMOVE_DROPLET_FROM_FIREWALL, data, params))
-        .getData();
+    return (Delete)
+        perform(new ApiRequest(ApiAction.REMOVE_DROPLET_FROM_FIREWALL, data, params)).getData();
   }
 
   @Override
@@ -1583,8 +1661,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throws DigitalOceanException, RequestUnsuccessfulException {
     validatePageNo(pageNo);
 
-    return (Firewalls) perform(new ApiRequest(ApiAction.AVAILABLE_FIREWALLS, pageNo, perPage))
-        .getData();
+    return (Firewalls)
+        perform(new ApiRequest(ApiAction.AVAILABLE_FIREWALLS, pageNo, perPage)).getData();
   }
 
   //
@@ -1717,7 +1795,8 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     int statusCode = httpResponse.getStatusLine().getStatusCode();
     String response = "";
 
-    if (HttpStatus.SC_OK == statusCode || HttpStatus.SC_CREATED == statusCode
+    if (HttpStatus.SC_OK == statusCode
+        || HttpStatus.SC_CREATED == statusCode
         || HttpStatus.SC_ACCEPTED == statusCode) {
       response = httpResponseToString(httpResponse);
     } else if (HttpStatus.SC_NO_CONTENT == statusCode) {
@@ -1737,12 +1816,14 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
         id = jsonObj.get("id").getAsString();
         errorMsg = jsonObj.get("message").getAsString();
       } catch (JsonSyntaxException e) {
-        errorMsg = "Digital Oceans server are on maintenance. Wait for official messages "
-            + "from digital ocean itself. Such as 'Cloud Control Panel, API & Support Ticket System Unavailable'";
+        errorMsg =
+            "Digital Oceans server are on maintenance. Wait for official messages "
+                + "from digital ocean itself. Such as 'Cloud Control Panel, API & Support Ticket System Unavailable'";
       }
 
-      String errorMsgFull = String.format("\nHTTP Status Code: %s\nError Id: %s\nError Message: %s",
-          statusCode, id, errorMsg);
+      String errorMsgFull =
+          String.format(
+              "\nHTTP Status Code: %s\nError Id: %s\nError Message: %s", statusCode, id, errorMsg);
       log.debug(errorMsgFull);
 
       throw new DigitalOceanException(errorMsg, id, statusCode);
@@ -1778,7 +1859,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     if (RequestMethod.GET == request.getMethod()) {
       if (null == request.getPerPage()) {
         ub.setParameter(PARAM_PER_PAGE, String.valueOf(DEFAULT_PAGE_SIZE)); // As per DO
-                                                                            // documentation
+        // documentation
       } else {
         ub.setParameter(PARAM_PER_PAGE, request.getPerPage().toString());
       }
@@ -1834,8 +1915,12 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       return response;
     }
 
-    String rateLimitData = String.format(RATE_LIMIT_JSON_STRUCT, rateLimit, rateRemaining,
-        getDateString(rateReset, DATE_FORMAT));
+    String rateLimitData =
+        String.format(
+            RATE_LIMIT_JSON_STRUCT,
+            rateLimit,
+            rateRemaining,
+            getDateString(rateReset, DATE_FORMAT));
     log.debug("RateLimitData:: {}", rateLimitData);
 
     return StringUtils.substringBeforeLast(response, "}") + ", " + rateLimitData + "}";
@@ -1852,9 +1937,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     return dateString;
   }
 
-  /**
-   * Easy method for HTTP header values (first/last)
-   */
+  /** Easy method for HTTP header values (first/last) */
   private String getSimpleHeaderValue(String header, HttpResponse httpResponse, boolean first) {
     if (StringUtils.isBlank(header)) {
       return StringUtils.EMPTY;
@@ -1872,9 +1955,7 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
     return h.getValue();
   }
 
-  /**
-   * Easy method for HTTP header values. defaults to first one.
-   */
+  /** Easy method for HTTP header values. defaults to first one. */
   private String getSimpleHeaderValue(String header, HttpResponse httpResponse) {
     return getSimpleHeaderValue(header, httpResponse, true);
   }
@@ -1924,13 +2005,15 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       throw new IllegalArgumentException("Missing required parameters [ForwardingRules]");
     }
 
-    for (ForwardingRules rule : rules)
-      validateForwardingRule(rule);
+    for (ForwardingRules rule : rules) validateForwardingRule(rule);
   }
 
   private void validateForwardingRule(ForwardingRules rule) {
-    if (null == rule || null == rule.getEntryProtocol() || null == rule.getEntryPort()
-        || null == rule.getTargetProtocol() || null == rule.getTargetPort()) {
+    if (null == rule
+        || null == rule.getEntryProtocol()
+        || null == rule.getEntryPort()
+        || null == rule.getTargetProtocol()
+        || null == rule.getTargetPort()) {
       throw new IllegalArgumentException(
           "Missing required parameters [Entry Protocol, Entry Port, Target Protocol, Target Port] for forwarding rules.");
     }
@@ -1947,18 +2030,23 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
   private void initialize() {
     this.deserialize = new GsonBuilder().setDateFormat(DATE_FORMAT).create();
 
-    this.serialize = new GsonBuilder().setDateFormat(DATE_FORMAT)
-        .registerTypeAdapter(Droplet.class, new DropletSerializer())
-        .registerTypeAdapter(Volume.class, new VolumeSerializer())
-        .registerTypeAdapter(LoadBalancer.class, new LoadBalancerSerializer())
-        .registerTypeAdapter(Firewall.class, new FirewallSerializer())
-        .excludeFieldsWithoutExposeAnnotation().create();
+    this.serialize =
+        new GsonBuilder()
+            .setDateFormat(DATE_FORMAT)
+            .registerTypeAdapter(Droplet.class, new DropletSerializer())
+            .registerTypeAdapter(Volume.class, new VolumeSerializer())
+            .registerTypeAdapter(LoadBalancer.class, new LoadBalancerSerializer())
+            .registerTypeAdapter(Firewall.class, new FirewallSerializer())
+            .excludeFieldsWithoutExposeAnnotation()
+            .create();
 
     this.jsonParser = new JsonParser();
 
-    Header[] headers = {new BasicHeader(HDR_USER_AGENT, USER_AGENT),
-        new BasicHeader(HDR_CONTENT_TYPE, JSON_CONTENT_TYPE),
-        new BasicHeader(HDR_AUTHORIZATION, "Bearer " + authToken)};
+    Header[] headers = {
+      new BasicHeader(HDR_USER_AGENT, USER_AGENT),
+      new BasicHeader(HDR_CONTENT_TYPE, JSON_CONTENT_TYPE),
+      new BasicHeader(HDR_AUTHORIZATION, "Bearer " + authToken)
+    };
     log.debug("API Request Headers:: " + headers);
 
     this.requestHeaders = headers;
@@ -1967,5 +2055,4 @@ public class DigitalOceanClient implements DigitalOcean, Constants {
       this.httpClient = HttpClients.createDefault();
     }
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Account.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Account.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Account attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Account extends Base {
@@ -59,100 +56,72 @@ public class Account extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the email
-   */
+  /** @return the email */
   public String getEmail() {
     return email;
   }
 
-  /**
-   * @param email the email to set
-   */
+  /** @param email the email to set */
   public void setEmail(String email) {
     this.email = email;
   }
 
-  /**
-   * @return the uuid
-   */
+  /** @return the uuid */
   public String getUuid() {
     return uuid;
   }
 
-  /**
-   * @param uuid the uuid to set
-   */
+  /** @param uuid the uuid to set */
   public void setUuid(String uuid) {
     this.uuid = uuid;
   }
 
-  /**
-   * @return the dropletLimit
-   */
+  /** @return the dropletLimit */
   public Integer getDropletLimit() {
     return dropletLimit;
   }
 
-  /**
-   * @param dropletLimit the dropletLimit to set
-   */
+  /** @param dropletLimit the dropletLimit to set */
   public void setDropletLimit(Integer dropletLimit) {
     this.dropletLimit = dropletLimit;
   }
 
-  /**
-   * @return the isEmailVerified
-   */
+  /** @return the isEmailVerified */
   public boolean isEmailVerified() {
     return isEmailVerified;
   }
 
-  /**
-   * @param isEmailVerified the isEmailVerified to set
-   */
+  /** @param isEmailVerified the isEmailVerified to set */
   public void setEmailVerified(boolean isEmailVerified) {
     this.isEmailVerified = isEmailVerified;
   }
 
-  /**
-   * @return the status
-   */
+  /** @return the status */
   public String getStatus() {
     return status;
   }
 
-  /**
-   * @param status the status to set
-   */
+  /** @param status the status to set */
   public void setStatus(String status) {
     this.status = status;
   }
 
-  /**
-   * @return the statusMessage
-   */
+  /** @return the statusMessage */
   public String getStatusMessage() {
     return statusMessage;
   }
 
-  /**
-   * @param statusMessage the statusMessage to set
-   */
+  /** @param statusMessage the statusMessage to set */
   public void setStatusMessage(String statusMessage) {
     this.statusMessage = statusMessage;
   }
 
-  /**
-   * @return the floatingIPLimit
-   */
+  /** @return the floatingIPLimit */
   public Integer getFloatingIPLimit() {
     return floatingIPLimit;
   }
 
-  /**
-   * @param floatingIPLimit the floatingIPLimit to set
-   */
+  /** @param floatingIPLimit the floatingIPLimit to set */
   public void setFloatingIPLimit(Integer floatingIPLimit) {
     this.floatingIPLimit = floatingIPLimit;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Action.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Action.java
@@ -1,40 +1,36 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.ActionStatus;
 import com.myjeeva.digitalocean.common.ActionType;
 import com.myjeeva.digitalocean.common.ResourceType;
+import java.util.Date;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Action attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Action extends Base {
@@ -69,128 +65,92 @@ public class Action extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the resourceId
-   */
+  /** @return the resourceId */
   public Long getResourceId() {
     return resourceId;
   }
 
-  /**
-   * @param resourceId the resourceId to set
-   */
+  /** @param resourceId the resourceId to set */
   public void setResourceId(Long resourceId) {
     this.resourceId = resourceId;
   }
 
-  /**
-   * @return the status
-   */
+  /** @return the status */
   public ActionStatus getStatus() {
     return status;
   }
 
-  /**
-   * @param status the status to set
-   */
+  /** @param status the status to set */
   public void setStatus(ActionStatus status) {
     this.status = status;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ActionType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ActionType type) {
     this.type = type;
   }
 
-  /**
-   * @return the resourceType
-   */
+  /** @return the resourceType */
   public ResourceType getResourceType() {
     return resourceType;
   }
 
-  /**
-   * @param resourceType the resourceType to set
-   */
+  /** @param resourceType the resourceType to set */
   public void setResourceType(ResourceType resourceType) {
     this.resourceType = resourceType;
   }
 
-  /**
-   * @return the startedAt
-   */
+  /** @return the startedAt */
   public Date getStartedAt() {
     return startedAt;
   }
 
-  /**
-   * @param startedAt the startedAt to set
-   */
+  /** @param startedAt the startedAt to set */
   public void setStartedAt(Date startedAt) {
     this.startedAt = startedAt;
   }
 
-  /**
-   * @return the completedAt
-   */
+  /** @return the completedAt */
   public Date getCompletedAt() {
     return completedAt;
   }
 
-  /**
-   * @param completedAt the completedAt to set
-   */
+  /** @param completedAt the completedAt to set */
   public void setCompletedAt(Date completedAt) {
     this.completedAt = completedAt;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public Region getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(Region region) {
     this.region = region;
   }
 
-  /**
-   * @return the regionSlug
-   */
+  /** @return the regionSlug */
   public String getRegionSlug() {
     return regionSlug;
   }
 
-  /**
-   * @param regionSlug the regionSlug to set
-   */
+  /** @param regionSlug the regionSlug to set */
   public void setRegionSlug(String regionSlug) {
     this.regionSlug = regionSlug;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Actions.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Actions.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Actions attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Actions extends Base {
@@ -43,16 +40,12 @@ public class Actions extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the actions
-   */
+  /** @return the actions */
   public List<Action> getActions() {
     return actions;
   }
 
-  /**
-   * @param actions the actions to set
-   */
+  /** @param actions the actions to set */
   public void setActions(List<Action> actions) {
     this.actions = actions;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Backup.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Backup.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 /**
  * Represents backup attributes of Droplet
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v1.4
  */
 public class Backup extends Image {
 
   private static final long serialVersionUID = 7827206749099471697L;
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Backups.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Backups.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
 
 /**
  * Represents Backups attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Backups extends Base {
@@ -36,16 +34,12 @@ public class Backups extends Base {
 
   List<Backup> backups;
 
-  /**
-   * @return the backups
-   */
+  /** @return the backups */
   public List<Backup> getBackups() {
     return backups;
   }
 
-  /**
-   * @param backups the backups to set
-   */
+  /** @param backups the backups to set */
   public void setBackups(List<Backup> backups) {
     this.backups = backups;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Base.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Base.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.io.Serializable;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Meta and Links attributes in Base class
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public abstract class Base extends RateLimitBase implements Serializable {
@@ -45,30 +42,22 @@ public abstract class Base extends RateLimitBase implements Serializable {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the meta
-   */
+  /** @return the meta */
   public Meta getMeta() {
     return meta;
   }
 
-  /**
-   * @param meta the meta to set
-   */
+  /** @param meta the meta to set */
   public void setMeta(Meta meta) {
     this.meta = meta;
   }
 
-  /**
-   * @return the links
-   */
+  /** @return the links */
   public Links getLinks() {
     return links;
   }
 
-  /**
-   * @param links the links to set
-   */
+  /** @param links the links to set */
   public void setLinks(Links links) {
     this.links = links;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Certificate.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Certificate.java
@@ -1,40 +1,36 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.CertificateState;
+import java.util.Date;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Certificate attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.12
  */
 public class Certificate extends Base {
@@ -43,8 +39,7 @@ public class Certificate extends Base {
 
   private String id;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
   @SerializedName("not_after")
   private String notAfter;
@@ -66,38 +61,30 @@ public class Certificate extends Base {
   @Expose
   @SerializedName("certificate_chain")
   private String certificateChain;
-  
-  @Expose
-  private CertificateState state;
-  
+
+  @Expose private CertificateState state;
+
   @Expose
   @SerializedName("dns_names")
   private List<String> dnsNames;
-  
-  @Expose
-  private String type;
 
-  /**
-   * Default Constructor.
-   */
+  @Expose private String type;
+
+  /** Default Constructor. */
   public Certificate() {
     // default constructor
   }
 
-  /**
-   * Constructor for new certificate create request.
-   */
-  public Certificate(String name, String privateKey, String leafCertificate,
-      String certificateChain) {
+  /** Constructor for new certificate create request. */
+  public Certificate(
+      String name, String privateKey, String leafCertificate, String certificateChain) {
     this.name = name;
     this.privateKey = privateKey;
     this.leafCertificate = leafCertificate;
     this.certificateChain = certificateChain;
   }
-  
-  /**
-   * Constructor for new Let's Encrypt certificate create request.
-   */
+
+  /** Constructor for new Let's Encrypt certificate create request. */
   public Certificate(String name, String type, List<String> dnsNames) {
     this.name = name;
     this.type = type;
@@ -109,158 +96,113 @@ public class Certificate extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public String getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(String id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the notAfter
-   */
+  /** @return the notAfter */
   public String getNotAfter() {
     return notAfter;
   }
 
-  /**
-   * @param notAfter the notAfter to set
-   */
+  /** @param notAfter the notAfter to set */
   public void setNotAfter(String notAfter) {
     this.notAfter = notAfter;
   }
 
-  /**
-   * @return the sha1Fingerprint
-   */
+  /** @return the sha1Fingerprint */
   public String getSha1Fingerprint() {
     return sha1Fingerprint;
   }
 
-  /**
-   * @param sha1Fingerprint the sha1Fingerprint to set
-   */
+  /** @param sha1Fingerprint the sha1Fingerprint to set */
   public void setSha1Fingerprint(String sha1Fingerprint) {
     this.sha1Fingerprint = sha1Fingerprint;
   }
 
-  /**
-   * @return the createdDate
-   */
+  /** @return the createdDate */
   public Date getCreatedDate() {
     return createdDate;
   }
 
-  /**
-   * @param createdDate the createdDate to set
-   */
+  /** @param createdDate the createdDate to set */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
-  /**
-   * @return the privateKey
-   */
+  /** @return the privateKey */
   public String getPrivateKey() {
     return privateKey;
   }
 
-  /**
-   * @param privateKey the privateKey to set
-   */
+  /** @param privateKey the privateKey to set */
   public void setPrivateKey(String privateKey) {
     this.privateKey = privateKey;
   }
 
-  /**
-   * @return the leafCertificate
-   */
+  /** @return the leafCertificate */
   public String getLeafCertificate() {
     return leafCertificate;
   }
 
-  /**
-   * @param leafCertificate the leafCertificate to set
-   */
+  /** @param leafCertificate the leafCertificate to set */
   public void setLeafCertificate(String leafCertificate) {
     this.leafCertificate = leafCertificate;
   }
 
-  /**
-   * @return the certificateChain
-   */
+  /** @return the certificateChain */
   public String getCertificateChain() {
     return certificateChain;
   }
 
-  /**
-   * @param certificateChain the certificateChain to set
-   */
+  /** @param certificateChain the certificateChain to set */
   public void setCertificateChain(String certificateChain) {
     this.certificateChain = certificateChain;
   }
 
-  /**
-   * @return the state
-   */
+  /** @return the state */
   public CertificateState getState() {
     return state;
   }
 
-  /**
-   * @param state the state to set
-   */
+  /** @param state the state to set */
   public void setState(CertificateState state) {
     this.state = state;
   }
 
-  /**
-   * @return the dnsNames
-   */
+  /** @return the dnsNames */
   public List<String> getDnsNames() {
     return dnsNames;
   }
 
-  /**
-   * @param dnsNames the dnsNames to set
-   */
+  /** @param dnsNames the dnsNames to set */
   public void setDnsNames(List<String> dnsNames) {
     this.dnsNames = dnsNames;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public String getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(String type) {
     this.type = type;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Certificates.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Certificates.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Certificates attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.12
  */
 public class Certificates extends Base {
@@ -43,18 +40,13 @@ public class Certificates extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the certificates
-   */
+  /** @return the certificates */
   public List<Certificate> getCertificates() {
     return certificates;
   }
 
-  /**
-   * @param certificates the certificates to set
-   */
+  /** @param certificates the certificates to set */
   public void setCertificates(List<Certificate> certificates) {
     this.certificates = certificates;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Delete.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Delete.java
@@ -1,49 +1,45 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents HTTP Method - DELETE response handling
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Delete extends Response {
 
   private static final long serialVersionUID = -3552374545843268569L;
 
-  /**
-   * Default Constructor
-   */
+  /** Default Constructor */
   public Delete() {
     // Default Constructor
   }
 
   /**
    * Parameterized Constructor
-   * 
+   *
    * @param isRequestSuccess whether delete is success or not
    */
   public Delete(Boolean isRequestSuccess) {
@@ -54,5 +50,4 @@ public class Delete extends Response {
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Destinations.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Destinations.java
@@ -1,31 +1,29 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.List;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 
 /**
  * Represents Destinations for OutboundRules used by Firewalls
@@ -34,8 +32,7 @@ import com.google.gson.annotations.SerializedName;
  */
 public class Destinations {
 
-  @Expose
-  private List<String> addresses;
+  @Expose private List<String> addresses;
 
   @Expose
   @SerializedName("droplet_ids")
@@ -45,8 +42,7 @@ public class Destinations {
   @SerializedName("load_balancer_uids")
   private List<String> loadBalancerUids;
 
-  @Expose
-  private List<String> tags;
+  @Expose private List<String> tags;
 
   public List<String> getAddresses() {
     return addresses;
@@ -79,5 +75,4 @@ public class Destinations {
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Domain.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Domain.java
@@ -1,42 +1,39 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Domain (TLD) attributes of DigitalOcean DNS. Revised as per v2 API data structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Domain extends Base {
 
   private static final long serialVersionUID = 5958407274594550472L;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
   @SerializedName("ttl")
   private Integer timeToLive;
@@ -62,58 +59,42 @@ public class Domain extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the timeToLive
-   */
+  /** @return the timeToLive */
   public Integer getTimeToLive() {
     return timeToLive;
   }
 
-  /**
-   * @param timeToLive the timeToLive to set
-   */
+  /** @param timeToLive the timeToLive to set */
   public void setTimeToLive(Integer timeToLive) {
     this.timeToLive = timeToLive;
   }
 
-  /**
-   * @return the zoneFile
-   */
+  /** @return the zoneFile */
   public String getZoneFile() {
     return zoneFile;
   }
 
-  /**
-   * @param zoneFile the zoneFile to set
-   */
+  /** @param zoneFile the zoneFile to set */
   public void setZoneFile(String zoneFile) {
     this.zoneFile = zoneFile;
   }
 
-  /**
-   * @return the ipAddress
-   */
+  /** @return the ipAddress */
   public String getIpAddress() {
     return ipAddress;
   }
 
-  /**
-   * @param ipAddress the ipAddress to set
-   */
+  /** @param ipAddress the ipAddress to set */
   public void setIpAddress(String ipAddress) {
     this.ipAddress = ipAddress;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/DomainRecord.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/DomainRecord.java
@@ -1,35 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.myjeeva.digitalocean.common.CaaTagType;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents DomainRecord (TLD) Record attributes of DigitalOcean DNS. Revised as per v2 API data
  * structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class DomainRecord extends Base {
@@ -38,32 +36,23 @@ public class DomainRecord extends Base {
 
   private Integer id;
 
-  @Expose
-  private String type;
+  @Expose private String type;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
-  @Expose
-  private String data;
+  @Expose private String data;
 
-  @Expose
-  private Integer priority;
+  @Expose private Integer priority;
 
-  @Expose
-  private Integer port;
+  @Expose private Integer port;
 
-  @Expose
-  private Integer weight;
+  @Expose private Integer weight;
 
-  @Expose
-  private Integer ttl;
-  
-  @Expose
-  private Integer flags;
-  
-  @Expose
-  private CaaTagType tag;
+  @Expose private Integer ttl;
+
+  @Expose private Integer flags;
+
+  @Expose private CaaTagType tag;
 
   public DomainRecord() {
     // Default Constructor
@@ -72,7 +61,7 @@ public class DomainRecord extends Base {
   public DomainRecord(String name) {
     this.name = name;
   }
-  
+
   public DomainRecord(String name, String type) {
     this(name, null, type, null, null, null);
   }
@@ -81,11 +70,19 @@ public class DomainRecord extends Base {
     this(name, data, type, null, null, null);
   }
 
-  public DomainRecord(String name, String data, String type, Integer priority, Integer port,
-                      Integer weight) { this(name, data, type, priority, null, null, null); }
+  public DomainRecord(
+      String name, String data, String type, Integer priority, Integer port, Integer weight) {
+    this(name, data, type, priority, null, null, null);
+  }
 
-  public DomainRecord(String name, String data, String type, Integer priority, Integer port,
-                      Integer weight, Integer ttl) {
+  public DomainRecord(
+      String name,
+      String data,
+      String type,
+      Integer priority,
+      Integer port,
+      Integer weight,
+      Integer ttl) {
     this.name = name;
     this.data = data;
     this.type = type;
@@ -100,144 +97,103 @@ public class DomainRecord extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public String getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(String type) {
     this.type = type;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the data
-   */
+  /** @return the data */
   public String getData() {
     return data;
   }
 
-  /**
-   * @param data the data to set
-   */
+  /** @param data the data to set */
   public void setData(String data) {
     this.data = data;
   }
 
-  /**
-   * @return the priority
-   */
+  /** @return the priority */
   public Integer getPriority() {
     return priority;
   }
 
-  /**
-   * @param priority the priority to set
-   */
+  /** @param priority the priority to set */
   public void setPriority(Integer priority) {
     this.priority = priority;
   }
 
-  /**
-   * @return the port
-   */
+  /** @return the port */
   public Integer getPort() {
     return port;
   }
 
-  /**
-   * @param port the port to set
-   */
+  /** @param port the port to set */
   public void setPort(Integer port) {
     this.port = port;
   }
 
-  /**
-   * @return the weight
-   */
+  /** @return the weight */
   public Integer getWeight() {
     return weight;
   }
 
-  /**
-   * @param weight the weight to set
-   */
+  /** @param weight the weight to set */
   public void setWeight(Integer weight) {
     this.weight = weight;
   }
 
-  /**
-   * @return the TTL, in seconds
-   */
+  /** @return the TTL, in seconds */
   public Integer getTtl() {
     return ttl;
   }
 
-  /**
-   * @param ttl the TTL, in seconds
-   */
+  /** @param ttl the TTL, in seconds */
   public void setTtl(Integer ttl) {
     this.ttl = ttl;
   }
 
-  /**
-   * @return the flags
-   */
+  /** @return the flags */
   public Integer getFlags() {
     return flags;
   }
 
-  /**
-   * @param flags the flags to set
-   */
+  /** @param flags the flags to set */
   public void setFlags(Integer flags) {
     this.flags = flags;
   }
 
-  /**
-   * @return the tag
-   */
+  /** @return the tag */
   public CaaTagType getTag() {
     return tag;
   }
 
-  /**
-   * @param tag the tag to set
-   */
+  /** @param tag the tag to set */
   public void setTag(CaaTagType tag) {
     this.tag = tag;
   }
-  
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/DomainRecords.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/DomainRecords.java
@@ -1,37 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Domain Records attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class DomainRecords extends Base {
@@ -46,16 +42,12 @@ public class DomainRecords extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the domainRecords
-   */
+  /** @return the domainRecords */
   public List<DomainRecord> getDomainRecords() {
     return domainRecords;
   }
 
-  /**
-   * @param domainRecords the domainRecords to set
-   */
+  /** @param domainRecords the domainRecords to set */
   public void setDomainRecords(List<DomainRecord> domainRecords) {
     this.domainRecords = domainRecords;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Domains.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Domains.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Domains attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Domains extends Base {
@@ -43,16 +40,12 @@ public class Domains extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the domains
-   */
+  /** @return the domains */
   public List<Domain> getDomains() {
     return domains;
   }
 
-  /**
-   * @param domains the domains to set
-   */
+  /** @param domains the domains to set */
   public void setDomains(List<Domain> domains) {
     this.domains = domains;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Droplet.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Droplet.java
@@ -1,37 +1,34 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.DropletStatus;
+import java.util.Date;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Droplet attributes of DigitalOcean. Revised as per v2 API data structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Droplet extends Base {
@@ -104,382 +101,273 @@ public class Droplet extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return true if droplet is active
-   */
+  /** @return true if droplet is active */
   public boolean isActive() {
     return DropletStatus.ACTIVE == status;
   }
 
-  /**
-   * @return true if droplet is new, meaning it's booting up
-   */
+  /** @return true if droplet is new, meaning it's booting up */
   public boolean isNew() {
     return DropletStatus.NEW == status;
   }
 
-  /**
-   * @return true if droplet is turned off
-   */
+  /** @return true if droplet is turned off */
   public boolean isOff() {
     return DropletStatus.OFF == status;
   }
 
-  /**
-   * @return true if droplet is archived
-   */
+  /** @return true if droplet is archived */
   public boolean isArchived() {
     return DropletStatus.ARCHIVE == status;
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the names
-   */
+  /** @return the names */
   public List<String> getNames() {
     return names;
   }
 
-  /**
-   * @param names the names to set
-   */
+  /** @param names the names to set */
   public void setNames(List<String> names) {
     this.names = names;
   }
 
-  /**
-   * @return the memorySizeInMb
-   */
+  /** @return the memorySizeInMb */
   public Integer getMemorySizeInMb() {
     return memorySizeInMb;
   }
 
-  /**
-   * @param memorySizeInMb the memorySizeInMb to set
-   */
+  /** @param memorySizeInMb the memorySizeInMb to set */
   public void setMemorySizeInMb(Integer memorySizeInMb) {
     this.memorySizeInMb = memorySizeInMb;
   }
 
-  /**
-   * @return the virutalCpuCount
-   */
+  /** @return the virutalCpuCount */
   public Integer getVirutalCpuCount() {
     return virutalCpuCount;
   }
 
-  /**
-   * @param virutalCpuCount the virutalCpuCount to set
-   */
+  /** @param virutalCpuCount the virutalCpuCount to set */
   public void setVirutalCpuCount(Integer virutalCpuCount) {
     this.virutalCpuCount = virutalCpuCount;
   }
 
-  /**
-   * @return the diskSize
-   */
+  /** @return the diskSize */
   public Integer getDiskSize() {
     return diskSize;
   }
 
-  /**
-   * @param diskSize the diskSize to set
-   */
+  /** @param diskSize the diskSize to set */
   public void setDiskSize(Integer diskSize) {
     this.diskSize = diskSize;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public Region getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(Region region) {
     this.region = region;
   }
 
-  /**
-   * @return the image
-   */
+  /** @return the image */
   public Image getImage() {
     return image;
   }
 
-  /**
-   * @param image the image to set
-   */
+  /** @param image the image to set */
   public void setImage(Image image) {
     this.image = image;
   }
 
-  /**
-   * @return the size
-   */
+  /** @return the size */
   public String getSize() {
     return size;
   }
 
-  /**
-   * @param size the size to set
-   */
+  /** @param size the size to set */
   public void setSize(String size) {
     this.size = size;
   }
 
-  /**
-   * @return the locked
-   */
+  /** @return the locked */
   public boolean isLocked() {
     return locked;
   }
 
-  /**
-   * @param locked the locked to set
-   */
+  /** @param locked the locked to set */
   public void setLocked(boolean locked) {
     this.locked = locked;
   }
 
-  /**
-   * @return the status
-   */
+  /** @return the status */
   public DropletStatus getStatus() {
     return status;
   }
 
-  /**
-   * @param status the status to set
-   */
+  /** @param status the status to set */
   public void setStatus(DropletStatus status) {
     this.status = status;
   }
 
-  /**
-   * @return the networks
-   */
+  /** @return the networks */
   public Networks getNetworks() {
     return networks;
   }
 
-  /**
-   * @param networks the networks to set
-   */
+  /** @param networks the networks to set */
   public void setNetworks(Networks networks) {
     this.networks = networks;
   }
 
-  /**
-   * @return the kernel
-   */
+  /** @return the kernel */
   public Kernel getKernel() {
     return kernel;
   }
 
-  /**
-   * @param kernel the kernel to set
-   */
+  /** @param kernel the kernel to set */
   public void setKernel(Kernel kernel) {
     this.kernel = kernel;
   }
 
-  /**
-   * @return the createdDate
-   */
+  /** @return the createdDate */
   public Date getCreatedDate() {
     return createdDate;
   }
 
-  /**
-   * @param createdDate the createdDate to set
-   */
+  /** @param createdDate the createdDate to set */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
-  /**
-   * @return the features
-   */
+  /** @return the features */
   public List<String> getFeatures() {
     return features;
   }
 
-  /**
-   * @param features the features to set
-   */
+  /** @param features the features to set */
   public void setFeatures(List<String> features) {
     this.features = features;
   }
 
-  /**
-   * @return the enableBackup
-   */
+  /** @return the enableBackup */
   public Boolean getEnableBackup() {
     return enableBackup;
   }
 
-  /**
-   * @param enableBackup the enableBackup to set
-   */
+  /** @param enableBackup the enableBackup to set */
   public void setEnableBackup(Boolean enableBackup) {
     this.enableBackup = enableBackup;
   }
 
-  /**
-   * @return the enableIpv6
-   */
+  /** @return the enableIpv6 */
   public Boolean getEnableIpv6() {
     return enableIpv6;
   }
 
-  /**
-   * @param enableIpv6 the enableIpv6 to set
-   */
+  /** @param enableIpv6 the enableIpv6 to set */
   public void setEnableIpv6(Boolean enableIpv6) {
     this.enableIpv6 = enableIpv6;
   }
 
-  /**
-   * @return the enablePrivateNetworking
-   */
+  /** @return the enablePrivateNetworking */
   public Boolean getEnablePrivateNetworking() {
     return enablePrivateNetworking;
   }
 
-  /**
-   * @param enablePrivateNetworking the enablePrivateNetworking to set
-   */
+  /** @param enablePrivateNetworking the enablePrivateNetworking to set */
   public void setEnablePrivateNetworking(Boolean enablePrivateNetworking) {
     this.enablePrivateNetworking = enablePrivateNetworking;
   }
 
-  /**
-   * @return the backupIds
-   */
+  /** @return the backupIds */
   public List<Integer> getBackupIds() {
     return backupIds;
   }
 
-  /**
-   * @param backupIds the backupIds to set
-   */
+  /** @param backupIds the backupIds to set */
   public void setBackupIds(List<Integer> backupIds) {
     this.backupIds = backupIds;
   }
 
-  /**
-   * @return the snapshotIds
-   */
+  /** @return the snapshotIds */
   public List<Integer> getSnapshotIds() {
     return snapshotIds;
   }
 
-  /**
-   * @param snapshotIds the snapshotIds to set
-   */
+  /** @param snapshotIds the snapshotIds to set */
   public void setSnapshotIds(List<Integer> snapshotIds) {
     this.snapshotIds = snapshotIds;
   }
 
-  /**
-   * @return the keys
-   */
+  /** @return the keys */
   public List<Key> getKeys() {
     return keys;
   }
 
-  /**
-   * @param keys the keys to set
-   */
+  /** @param keys the keys to set */
   public void setKeys(List<Key> keys) {
     this.keys = keys;
   }
 
-  /**
-   * @return the userData
-   */
+  /** @return the userData */
   public String getUserData() {
     return userData;
   }
 
-  /**
-   * @param userData the userData to set
-   */
+  /** @param userData the userData to set */
   public void setUserData(String userData) {
     this.userData = userData;
   }
 
-  /**
-   * @return the volumeIds
-   */
+  /** @return the volumeIds */
   public List<String> getVolumeIds() {
     return volumeIds;
   }
 
-  /**
-   * @param volumeIds the volumeIds to set
-   */
+  /** @param volumeIds the volumeIds to set */
   public void setVolumeIds(List<String> volumeIds) {
     this.volumeIds = volumeIds;
   }
 
-  /**
-   * @return the tags
-   */
+  /** @return the tags */
   public List<String> getTags() {
     return tags;
   }
 
-  /**
-   * @param tags the tags to set
-   */
+  /** @param tags the tags to set */
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
 
-  /**
-   * @return the installMonitoring
-   */
+  /** @return the installMonitoring */
   public Boolean getInstallMonitoring() {
     return installMonitoring;
   }
 
-  /**
-   * @param installMonitoring the installMonitoring to set
-   */
+  /** @param installMonitoring the installMonitoring to set */
   public void setInstallMonitoring(Boolean installMonitoring) {
     this.installMonitoring = installMonitoring;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/DropletAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/DropletAction.java
@@ -1,57 +1,48 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.myjeeva.digitalocean.common.ActionType;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Droplet Actions like reboot, powercycle, power on , power off, etc.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class DropletAction {
 
-  @Expose
-  private ActionType type;
+  @Expose private ActionType type;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
-  @Expose
-  private Integer image;
+  @Expose private Integer image;
 
-  @Expose
-  private Integer kernel;
+  @Expose private Integer kernel;
 
-  @Expose
-  private String size;
+  @Expose private String size;
 
-  @Expose
-  private Boolean disk;
+  @Expose private Boolean disk;
 
   public DropletAction() {
     // Default Constructor
@@ -66,86 +57,62 @@ public class DropletAction {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ActionType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ActionType type) {
     this.type = type;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the image
-   */
+  /** @return the image */
   public Integer getImage() {
     return image;
   }
 
-  /**
-   * @param image the image to set
-   */
+  /** @param image the image to set */
   public void setImage(Integer image) {
     this.image = image;
   }
 
-  /**
-   * @return the kernel
-   */
+  /** @return the kernel */
   public Integer getKernel() {
     return kernel;
   }
 
-  /**
-   * @param kernel the kernel to set
-   */
+  /** @param kernel the kernel to set */
   public void setKernel(Integer kernel) {
     this.kernel = kernel;
   }
 
-  /**
-   * @return the size
-   */
+  /** @return the size */
   public String getSize() {
     return size;
   }
 
-  /**
-   * @param size the size to set
-   */
+  /** @param size the size to set */
   public void setSize(String size) {
     this.size = size;
   }
 
-  /**
-   * @return the disk
-   */
+  /** @return the disk */
   public Boolean getDisk() {
     return disk;
   }
 
-  /**
-   * @param disk the size to set
-   */
+  /** @param disk the size to set */
   public void setDisk(Boolean disk) {
     this.disk = disk;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Droplets.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Droplets.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Droplets attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Droplets extends Base {
@@ -43,16 +40,12 @@ public class Droplets extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the droplets
-   */
+  /** @return the droplets */
   public List<Droplet> getDroplets() {
     return droplets;
   }
 
-  /**
-   * @param droplets the droplets to set
-   */
+  /** @param droplets the droplets to set */
   public void setDroplets(List<Droplet> droplets) {
     this.droplets = droplets;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Firewall.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Firewall.java
@@ -1,38 +1,35 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import java.util.Date;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Firewall attributes of DigitalOcean. Revised as per v2 API data structure.
- * 
+ *
  * @author Lucas Andrey B. (andreybleme1@gmail.com)
  */
 public class Firewall extends Base {
@@ -141,5 +138,4 @@ public class Firewall extends Base {
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Firewalls.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Firewalls.java
@@ -1,45 +1,42 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Firewalls attributes.
- * 
+ *
  * @author Lucas Andrey B. (andreybleme1@gmail.com)
  */
 public class Firewalls extends Base {
 
   private static final long serialVersionUID = -6358515137857888620L;
-  
+
   @SerializedName("firewalls")
   private List<Firewall> firewalls;
-  
+
   @Override
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
@@ -52,5 +49,4 @@ public class Firewalls extends Base {
   public void setFirewalls(List<Firewall> firewalls) {
     this.firewalls = firewalls;
   }
-  
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIP.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIP.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Floating IP object
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.3
  */
 public class FloatingIP extends Base {
@@ -47,58 +45,42 @@ public class FloatingIP extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the ip
-   */
+  /** @return the ip */
   public String getIp() {
     return ip;
   }
 
-  /**
-   * @param ip the ip to set
-   */
+  /** @param ip the ip to set */
   public void setIp(String ip) {
     this.ip = ip;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public Region getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(Region region) {
     this.region = region;
   }
 
-  /**
-   * @return the droplet
-   */
+  /** @return the droplet */
   public Droplet getDroplet() {
     return droplet;
   }
 
-  /**
-   * @param droplet the droplet to set
-   */
+  /** @param droplet the droplet to set */
   public void setDroplet(Droplet droplet) {
     this.droplet = droplet;
   }
 
-  /**
-   * @return the locked
-   */
+  /** @return the locked */
   public boolean isLocked() {
     return locked;
   }
 
-  /**
-   * @param locked the locked to set
-   */
+  /** @param locked the locked to set */
   public void setLocked(boolean locked) {
     this.locked = locked;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIPAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIPAction.java
@@ -1,36 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Floating IP Action attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.3
  */
 public class FloatingIPAction extends Base {
@@ -41,11 +38,9 @@ public class FloatingIPAction extends Base {
   @SerializedName("droplet_id")
   private Integer dropletId;
 
-  @Expose
-  private String region;
+  @Expose private String region;
 
-  @Expose
-  private String type;
+  @Expose private String type;
 
   public FloatingIPAction() {
     // default constructor
@@ -74,44 +69,32 @@ public class FloatingIPAction extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the dropletId
-   */
+  /** @return the dropletId */
   public Integer getDropletId() {
     return dropletId;
   }
 
-  /**
-   * @param dropletId the dropletId to set
-   */
+  /** @param dropletId the dropletId to set */
   public void setDropletId(Integer dropletId) {
     this.dropletId = dropletId;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public String getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(String region) {
     this.region = region;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public String getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(String type) {
     this.type = type;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIPs.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/FloatingIPs.java
@@ -1,43 +1,39 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Floatung IPs attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.3
  */
 public class FloatingIPs extends Base {
 
   private static final long serialVersionUID = -5205906300992553434L;
-  
+
   @SerializedName("floating_ips")
   private List<FloatingIP> floatingIPs;
 
@@ -46,16 +42,12 @@ public class FloatingIPs extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the floatingIPs
-   */
+  /** @return the floatingIPs */
   public List<FloatingIP> getFloatingIPs() {
     return floatingIPs;
   }
 
-  /**
-   * @param floatingIPs the floatingIPs to set
-   */
+  /** @param floatingIPs the floatingIPs to set */
   public void setFloatingIPs(List<FloatingIP> floatingIPs) {
     this.floatingIPs = floatingIPs;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/ForwardingRules.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/ForwardingRules.java
@@ -1,24 +1,23 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import com.google.gson.annotations.Expose;
@@ -30,7 +29,6 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
  * Represents DigitalOcean Load Balancer forwarding rule object
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public class ForwardingRules extends Base {
@@ -66,9 +64,7 @@ public class ForwardingRules extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the entry protocol
-   */
+  /** @return the entry protocol */
   public Protocol getEntryProtocol() {
     return entryProtocol;
   }
@@ -77,74 +73,53 @@ public class ForwardingRules extends Base {
     this.entryProtocol = entryProtocol;
   }
 
-  /**
-   * @return the entry port
-   */
+  /** @return the entry port */
   public Integer getEntryPort() {
     return entryPort;
   }
 
-  /**
-   * @param entryPort the entry port to set
-   */
+  /** @param entryPort the entry port to set */
   public void setEntryPort(Integer entryPort) {
     this.entryPort = entryPort;
   }
 
-  /**
-   * @return the target protocol
-   */
+  /** @return the target protocol */
   public Protocol getTargetProtocol() {
     return targetProtocol;
   }
 
-  /**
-   * @param targetProtocol the target protocol to set
-   */
+  /** @param targetProtocol the target protocol to set */
   public void setTargetProtocol(Protocol targetProtocol) {
     this.targetProtocol = targetProtocol;
   }
 
-  /**
-   * @return the target port
-   */
+  /** @return the target port */
   public Integer getTargetPort() {
     return targetPort;
   }
 
-  /**
-   * @param targetPort the target port to set
-   */
+  /** @param targetPort the target port to set */
   public void setTargetPort(Integer targetPort) {
     this.targetPort = targetPort;
   }
 
-  /**
-   * @return the certificateId
-   */
+  /** @return the certificateId */
   public String getCertificateId() {
     return certificateId;
   }
 
-  /**
-   * @param certificateId the certificateId to set
-   */
+  /** @param certificateId the certificateId to set */
   public void setCertificateId(String certificateId) {
     this.certificateId = certificateId;
   }
 
-  /**
-   * @return true if SSL encrypted traffic will be passed through to the backend Droplets
-   */
+  /** @return true if SSL encrypted traffic will be passed through to the backend Droplets */
   public boolean isTlsPassthrough() {
     return tlsPassthrough;
   }
 
-  /**
-   * @param tlsPassthrough the tlsPassthrough to set
-   */
+  /** @param tlsPassthrough the tlsPassthrough to set */
   public void setTlsPassthrough(boolean tlsPassthrough) {
     this.tlsPassthrough = tlsPassthrough;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/HealthCheck.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/HealthCheck.java
@@ -1,24 +1,23 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import com.google.gson.annotations.Expose;
@@ -30,21 +29,17 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
  * Represents DigitalOcean Load Balancer health check object
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public class HealthCheck extends Base {
 
   private static final long serialVersionUID = -442836096026412279L;
 
-  @Expose
-  private Protocol protocol;
+  @Expose private Protocol protocol;
 
-  @Expose
-  private Integer port;
+  @Expose private Integer port;
 
-  @Expose
-  private String path;
+  @Expose private String path;
 
   @Expose
   @SerializedName("check_interval_seconds")
@@ -67,51 +62,39 @@ public class HealthCheck extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the protocol
-   */
+  /** @return the protocol */
   public Protocol getProtocol() {
     return protocol;
   }
 
-  /**
-   * @param protocol the protocol to set
-   */
+  /** @param protocol the protocol to set */
   public void setProtocol(Protocol protocol) {
     this.protocol = protocol;
   }
 
-  /**
-   * @return the port
-   */
+  /** @return the port */
   public Integer getPort() {
     return port;
   }
 
-  /**
-   * @param port the entry port to set
-   */
+  /** @param port the entry port to set */
   public void setPort(Integer port) {
     this.port = port;
   }
 
-  /**
-   * @return the path
-   */
+  /** @return the path */
   public String getPath() {
     return path;
   }
 
-  /**
-   * @param path the path to set
-   */
+  /** @param path the path to set */
   public void setPath(String path) {
     this.path = path;
   }
 
   /**
    * @return the number of times a health check must pass for a backend Droplet to be marked
-   *         "healthy" and be re-added to the pool
+   *     "healthy" and be re-added to the pool
    */
   public Integer getHealthyThreshold() {
     return healthyThreshold;
@@ -119,7 +102,7 @@ public class HealthCheck extends Base {
 
   /**
    * @param healthyThreshold the number of times a health check must pass for a backend Droplet to
-   *        be marked "healthy" and be re-added to the pool
+   *     be marked "healthy" and be re-added to the pool
    */
   public void setHealthyThreshold(Integer healthyThreshold) {
     this.healthyThreshold = healthyThreshold;
@@ -127,7 +110,7 @@ public class HealthCheck extends Base {
 
   /**
    * @return the number of times a health check must fail for a backend Droplet to be marked
-   *         "unhealthy" and be removed from the pool.
+   *     "unhealthy" and be removed from the pool.
    */
   public Integer getUnhealthyThreshold() {
     return unhealthyThreshold;
@@ -135,7 +118,7 @@ public class HealthCheck extends Base {
 
   /**
    * @param unhealthyThreshold the number of times a health check must fail for a backend Droplet to
-   *        be marked "unhealthy" and be removed from the pool.
+   *     be marked "unhealthy" and be removed from the pool.
    */
   public void setUnhealthyThreshold(Integer unhealthyThreshold) {
     this.unhealthyThreshold = unhealthyThreshold;
@@ -143,7 +126,7 @@ public class HealthCheck extends Base {
 
   /**
    * @return the number of seconds the Load Balancer instance will wait for a response until marking
-   *         a health check as failed.
+   *     a health check as failed.
    */
   public Integer getResponseTimeoutInSeconds() {
     return responseTimeoutInSeconds;
@@ -151,22 +134,20 @@ public class HealthCheck extends Base {
 
   /**
    * @param responseTimeoutInSeconds the number of seconds the Load Balancer instance will wait for
-   *        a response until marking a health check as failed.
+   *     a response until marking a health check as failed.
    */
   public void setResponseTimeoutInSeconds(Integer responseTimeoutInSeconds) {
     this.responseTimeoutInSeconds = responseTimeoutInSeconds;
   }
 
-  /**
-   * @return number of seconds between two consecutive health checks
-   */
+  /** @return number of seconds between two consecutive health checks */
   public Integer getCheckIntervalInSeconds() {
     return checkIntervalInSeconds;
   }
 
   /**
    * @param checkIntervalInSeconds the number of seconds between two consecutive health checks to
-   *        set
+   *     set
    */
   public void setCheckIntervalInSeconds(Integer checkIntervalInSeconds) {
     this.checkIntervalInSeconds = checkIntervalInSeconds;

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Image.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Image.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.ImageStatus;
 import com.myjeeva.digitalocean.common.ImageType;
+import java.util.Date;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Droplet Image (also public images aka Distribution) attributes of DigitalOcean
@@ -43,11 +40,9 @@ public class Image extends Base {
 
   private Integer id;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
-  @Expose
-  private String distribution;
+  @Expose private String distribution;
 
   private String slug;
 
@@ -66,23 +61,19 @@ public class Image extends Base {
   private Double size;
 
   private ImageType type;
-  
+
   // #89 - start
   // https://developers.digitalocean.com/documentation/changelog/api-v2/support-for-custom-images-and-image-tagging/
-  @Expose
-  private String url;
-  
-  @Expose
-  private String region;
-  
-  @Expose
-  private String description;
-  
-  @Expose
-  private List<String> tags;
-  
+  @Expose private String url;
+
+  @Expose private String region;
+
+  @Expose private String description;
+
+  @Expose private List<String> tags;
+
   private ImageStatus status;
-  
+
   @SerializedName("error_message")
   private String errorMessage;
   // #89 - end
@@ -98,7 +89,7 @@ public class Image extends Base {
   public Image(String slug) {
     this.slug = slug;
   }
-  
+
   public Image(String name, String url, String region) {
     this.name = name;
     this.url = url;
@@ -110,66 +101,53 @@ public class Image extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return true if image is snapshot
-   */
+  /** @return true if image is snapshot */
   public boolean isSnapshot() {
     return ImageType.SNAPSHOT == type;
   }
 
-  /**
-   * @return true if image is backup
-   */
+  /** @return true if image is backup */
   public boolean isBackup() {
     return ImageType.BACKUP == type;
   }
 
   /**
    * @return true if image is temporary Deprecated Info:
-   *         https://developers.digitalocean.com/documentation/changelog/api-v2/deprecate-final-
-   *         snaphots/
+   *     https://developers.digitalocean.com/documentation/changelog/api-v2/deprecate-final-
+   *     snaphots/
    */
   @Deprecated
   public boolean isTemporary() {
     return ImageType.TEMPORARY == type;
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
   /**
-   * The name of a custom image's distribution. 
-   * 
-   * <p>Currently, the valid values are "Arch Linux", "CentOS", "CoreOS", "Debian", 
-   * "Fedora", "Fedora Atomic", "FreeBSD", "Gentoo", "openSUSE", "RancherOS", "Ubuntu", 
-   * and "Unknown". Any other value will be accepted but ignored, 
-   * and "Unknown" will be used in its place. </p>
-   * 
+   * The name of a custom image's distribution.
+   *
+   * <p>Currently, the valid values are "Arch Linux", "CentOS", "CoreOS", "Debian", "Fedora",
+   * "Fedora Atomic", "FreeBSD", "Gentoo", "openSUSE", "RancherOS", "Ubuntu", and "Unknown". Any
+   * other value will be accepted but ignored, and "Unknown" will be used in its place.
+   *
    * @return the distribution
    */
   public String getDistribution() {
@@ -177,204 +155,151 @@ public class Image extends Base {
   }
 
   /**
-   * The name of a custom image's distribution. 
-   * 
-   * <p>Currently, the valid values are "Arch Linux", "CentOS", "CoreOS", "Debian", 
-   * "Fedora", "Fedora Atomic", "FreeBSD", "Gentoo", "openSUSE", "RancherOS", "Ubuntu", 
-   * and "Unknown". Any other value will be accepted but ignored, 
-   * and "Unknown" will be used in its place. </p>
-   * 
+   * The name of a custom image's distribution.
+   *
+   * <p>Currently, the valid values are "Arch Linux", "CentOS", "CoreOS", "Debian", "Fedora",
+   * "Fedora Atomic", "FreeBSD", "Gentoo", "openSUSE", "RancherOS", "Ubuntu", and "Unknown". Any
+   * other value will be accepted but ignored, and "Unknown" will be used in its place.
+   *
    * @param distribution the distribution to set
    */
   public void setDistribution(String distribution) {
     this.distribution = distribution;
   }
 
-  /**
-   * @return the slug
-   */
+  /** @return the slug */
   public String getSlug() {
     return slug;
   }
 
-  /**
-   * @param slug the slug to set
-   */
+  /** @param slug the slug to set */
   public void setSlug(String slug) {
     this.slug = slug;
   }
 
-  /**
-   * @return the availablePublic
-   */
+  /** @return the availablePublic */
   public boolean isAvailablePublic() {
     return availablePublic;
   }
 
-  /**
-   * @param availablePublic the availablePublic to set
-   */
+  /** @param availablePublic the availablePublic to set */
   public void setAvailablePublic(boolean availablePublic) {
     this.availablePublic = availablePublic;
   }
 
-  /**
-   * @return the regions
-   */
+  /** @return the regions */
   public List<String> getRegions() {
     return regions;
   }
 
-  /**
-   * @param regions the regions to set
-   */
+  /** @param regions the regions to set */
   public void setRegions(List<String> regions) {
     this.regions = regions;
   }
 
-  /**
-   * @return the createdDate
-   */
+  /** @return the createdDate */
   public Date getCreatedDate() {
     return createdDate;
   }
 
-  /**
-   * @param createdDate the createdDate to set
-   */
+  /** @param createdDate the createdDate to set */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ImageType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ImageType type) {
     this.type = type;
   }
 
-  /**
-   * @return the min Disk Size
-   */
+  /** @return the min Disk Size */
   public Integer getMinDiskSize() {
     return minDiskSize;
   }
 
-  /**
-   * @param minDiskSize the minDiskSize to set
-   */
+  /** @param minDiskSize the minDiskSize to set */
   public void setMinDiskSize(Integer minDiskSize) {
     this.minDiskSize = minDiskSize;
   }
 
-  /**
-   * @return the size
-   */
+  /** @return the size */
   public Double getSize() {
     return size;
   }
 
-  /**
-   * @param size the size to set
-   */
+  /** @param size the size to set */
   public void setSize(Double size) {
     this.size = size;
   }
 
-  /**
-   * @return the url
-   */
+  /** @return the url */
   public String getUrl() {
     return url;
   }
 
   /**
-   * A URL from which the custom Linux virtual machine image may be retrieved. 
-   * The image it points to must be in the raw, qcow2, vhdx, vdi, or vmdk format. 
-   * It may be compressed using gzip or bzip2 and must be smaller 
-   * than 100 GB after being decompressed.
-   * 
+   * A URL from which the custom Linux virtual machine image may be retrieved. The image it points
+   * to must be in the raw, qcow2, vhdx, vdi, or vmdk format. It may be compressed using gzip or
+   * bzip2 and must be smaller than 100 GB after being decompressed.
+   *
    * @param url the url to set
    */
   public void setUrl(String url) {
     this.url = url;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public String getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(String region) {
     this.region = region;
   }
 
-  /**
-   * @return the description
-   */
+  /** @return the description */
   public String getDescription() {
     return description;
   }
 
-  /**
-   * @param description the description to set
-   */
+  /** @param description the description to set */
   public void setDescription(String description) {
     this.description = description;
   }
 
-  /**
-   * @return the status
-   */
+  /** @return the status */
   public ImageStatus getStatus() {
     return status;
   }
 
-  /**
-   * @param status the status to set
-   */
+  /** @param status the status to set */
   public void setStatus(ImageStatus status) {
     this.status = status;
   }
 
-  /**
-   * @return the tags
-   */
+  /** @return the tags */
   public List<String> getTags() {
     return tags;
   }
 
-  /**
-   * @param tags the tags to set
-   */
+  /** @param tags the tags to set */
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
 
-  /**
-   * @return the errorMessage
-   */
+  /** @return the errorMessage */
   public String getErrorMessage() {
     return errorMessage;
   }
 
-  /**
-   * @param errorMessage the errorMessage to set
-   */
+  /** @param errorMessage the errorMessage to set */
   public void setErrorMessage(String errorMessage) {
     this.errorMessage = errorMessage;
   }
-  
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/ImageAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/ImageAction.java
@@ -1,50 +1,45 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.myjeeva.digitalocean.common.ActionType;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Image Actions like transfer.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class ImageAction {
 
-  @Expose
-  private ActionType type;
+  @Expose private ActionType type;
 
-  @Expose
-  private String region;
+  @Expose private String region;
 
   public ImageAction() {
     this(null, null);
   }
-  
+
   public ImageAction(ActionType type) {
     this(type, null);
   }
@@ -59,30 +54,22 @@ public class ImageAction {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ActionType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ActionType type) {
     this.type = type;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public String getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(String region) {
     this.region = region;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Images.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Images.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Images attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Images extends Base {
@@ -43,16 +40,12 @@ public class Images extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the images
-   */
+  /** @return the images */
   public List<Image> getImages() {
     return images;
   }
 
-  /**
-   * @param images the images to set
-   */
+  /** @param images the images to set */
   public void setImages(List<Image> images) {
     this.images = images;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/InboundRules.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/InboundRules.java
@@ -1,31 +1,29 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents InboundRules for Firewalls
@@ -74,5 +72,4 @@ public class InboundRules {
   public void setSources(Sources sources) {
     this.sources = sources;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Kernel.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Kernel.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents DigitalOcean Kernel attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Kernel extends Base {
@@ -45,44 +43,32 @@ public class Kernel extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the version
-   */
+  /** @return the version */
   public String getVersion() {
     return version;
   }
 
-  /**
-   * @param version the version to set
-   */
+  /** @param version the version to set */
   public void setVersion(String version) {
     this.version = version;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Kernels.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Kernels.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Kernels attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Kernels extends Base {
@@ -43,16 +40,12 @@ public class Kernels extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the kernels
-   */
+  /** @return the kernels */
   public List<Kernel> getKernels() {
     return kernels;
   }
 
-  /**
-   * @param kernels the kernels to set
-   */
+  /** @param kernels the kernels to set */
   public void setKernels(List<Kernel> kernels) {
     this.kernels = kernels;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Key.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Key.java
@@ -1,48 +1,43 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents SSH Key attributes of DigitalOcean. Revised as per v2 API data structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Key extends Base {
 
   private static final long serialVersionUID = 3454646433241484585L;
 
-  @Expose
-  private Integer id;
+  @Expose private Integer id;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
-  @Expose
-  private String fingerprint;
+  @Expose private String fingerprint;
 
   @Expose
   @SerializedName("public_key")
@@ -70,58 +65,42 @@ public class Key extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the fingerprint
-   */
+  /** @return the fingerprint */
   public String getFingerprint() {
     return fingerprint;
   }
 
-  /**
-   * @param fingerprint the fingerprint to set
-   */
+  /** @param fingerprint the fingerprint to set */
   public void setFingerprint(String fingerprint) {
     this.fingerprint = fingerprint;
   }
 
-  /**
-   * @return the publicKey
-   */
+  /** @return the publicKey */
   public String getPublicKey() {
     return publicKey;
   }
 
-  /**
-   * @param publicKey the publicKey to set
-   */
+  /** @param publicKey the publicKey to set */
   public void setPublicKey(String publicKey) {
     this.publicKey = publicKey;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Keys.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Keys.java
@@ -1,37 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Keys attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Keys extends Base {
@@ -46,16 +42,12 @@ public class Keys extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the keys
-   */
+  /** @return the keys */
   public List<Key> getKeys() {
     return keys;
   }
 
-  /**
-   * @param keys the keys to set
-   */
+  /** @param keys the keys to set */
   public void setKeys(List<Key> keys) {
     this.keys = keys;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/LinkAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/LinkAction.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Action attributes in the Links Actions section
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.3
  */
 public class LinkAction {
@@ -43,44 +41,32 @@ public class LinkAction {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public Integer getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(Integer id) {
     this.id = id;
   }
 
-  /**
-   * @return the rel
-   */
+  /** @return the rel */
   public String getRel() {
     return rel;
   }
 
-  /**
-   * @param rel the rel to set
-   */
+  /** @param rel the rel to set */
   public void setRel(String rel) {
     this.rel = rel;
   }
 
-  /**
-   * @return the href
-   */
+  /** @return the href */
   public String getHref() {
     return href;
   }
 
-  /**
-   * @param href the href to set
-   */
+  /** @param href the href to set */
   public void setHref(String href) {
     this.href = href;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Links.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Links.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Links attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Links {
@@ -43,30 +40,22 @@ public class Links {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the pages
-   */
+  /** @return the pages */
   public Pages getPages() {
     return pages;
   }
 
-  /**
-   * @param pages the pages to set
-   */
+  /** @param pages the pages to set */
   public void setPages(Pages pages) {
     this.pages = pages;
   }
 
-  /**
-   * @return the actions
-   */
+  /** @return the actions */
   public List<LinkAction> getActions() {
     return actions;
   }
 
-  /**
-   * @param actions the actions to set
-   */
+  /** @param actions the actions to set */
   public void setActions(List<LinkAction> actions) {
     this.actions = actions;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/LoadBalancer.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/LoadBalancer.java
@@ -1,40 +1,37 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.Date;
-import java.util.List;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.LoadBalancerStatus;
 import com.myjeeva.digitalocean.common.LoadBalancingAlgorithm;
+import java.util.Date;
+import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Load Balancer object
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public class LoadBalancer extends Base {
@@ -43,13 +40,11 @@ public class LoadBalancer extends Base {
 
   private String id;
 
-  @Expose
-  private String name;
+  @Expose private String name;
 
   private String ip;
 
-  @Expose
-  private LoadBalancingAlgorithm algorithm;
+  @Expose private LoadBalancingAlgorithm algorithm;
 
   private Region region;
 
@@ -73,195 +68,143 @@ public class LoadBalancer extends Base {
   @SerializedName("droplet_ids")
   private List<String> dropletIds;
 
-  @Expose
-  private String tag;
+  @Expose private String tag;
 
   @Override
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the ip
-   */
+  /** @return the ip */
   public String getIp() {
     return ip;
   }
 
-  /**
-   * @param ip the ip to set
-   */
+  /** @param ip the ip to set */
   public void setIp(String ip) {
     this.ip = ip;
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public String getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(String id) {
     this.id = id;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the algorithm
-   */
+  /** @return the algorithm */
   public LoadBalancingAlgorithm getAlgorithm() {
     return algorithm;
   }
 
-  /**
-   * @param algorithm the algorithm to set
-   */
+  /** @param algorithm the algorithm to set */
   public void setAlgorithm(LoadBalancingAlgorithm algorithm) {
     this.algorithm = algorithm;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public Region getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(Region region) {
     this.region = region;
   }
 
-  /**
-   * @return the status
-   */
+  /** @return the status */
   public LoadBalancerStatus getStatus() {
     return status;
   }
 
-  /**
-   * @param status the status to set
-   */
+  /** @param status the status to set */
   public void setStatus(LoadBalancerStatus status) {
     this.status = status;
   }
 
-  /**
-   * @return the created date
-   */
+  /** @return the created date */
   public Date getCreatedDate() {
     return createdDate;
   }
 
-  /**
-   * @param createdDate the createdDate to set
-   */
+  /** @param createdDate the createdDate to set */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
-  /**
-   * @return the forwarding rules
-   */
+  /** @return the forwarding rules */
   public List<ForwardingRules> getForwardingRules() {
     return forwardingRules;
   }
 
-  /**
-   * @param forwardingRules the forwardingRules to set
-   */
+  /** @param forwardingRules the forwardingRules to set */
   public void setForwardingRules(List<ForwardingRules> forwardingRules) {
     this.forwardingRules = forwardingRules;
   }
 
-  /**
-   * @return the healthcheck
-   */
+  /** @return the healthcheck */
   public HealthCheck getHealthCheck() {
     return healthCheck;
   }
 
-  /**
-   * @param healthCheck the healthCheck to set
-   */
+  /** @param healthCheck the healthCheck to set */
   public void setHealthCheck(HealthCheck healthCheck) {
     this.healthCheck = healthCheck;
   }
 
-  /**
-   * @return the sticky sessions
-   */
+  /** @return the sticky sessions */
   public StickySessions getStickySessions() {
     return stickySessions;
   }
 
-  /**
-   * @param stickySessions the stickySessions to set
-   */
+  /** @param stickySessions the stickySessions to set */
   public void setStickySessions(StickySessions stickySessions) {
     this.stickySessions = stickySessions;
   }
 
   /**
    * @return true if the HTTP requests to the Load Balancer on port 80 will be redirected to HTTPS
-   *         on port 443.
+   *     on port 443.
    */
   public boolean isRedirectHttpToHttps() {
     return redirectHttpToHttps;
   }
 
-  /**
-   * @param redirectHttpToHttps the redirectHttpToHttps to set
-   */
+  /** @param redirectHttpToHttps the redirectHttpToHttps to set */
   public void setRedirectHttpToHttps(boolean redirectHttpToHttps) {
     this.redirectHttpToHttps = redirectHttpToHttps;
   }
 
-  /**
-   * @return the list of dropletId
-   */
+  /** @return the list of dropletId */
   public List<String> getDropletIds() {
     return dropletIds;
   }
 
-  /**
-   * @param dropletIds the dropletIds to set
-   */
+  /** @param dropletIds the dropletIds to set */
   public void setDropletIds(List<String> dropletIds) {
     this.dropletIds = dropletIds;
   }
 
-  /**
-   * @return the tag
-   */
+  /** @return the tag */
   public String getTag() {
     return tag;
   }
 
-  /**
-   * @param tag the tag to set
-   */
+  /** @param tag the tag to set */
   public void setTag(String tag) {
     this.tag = tag;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/LoadBalancers.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/LoadBalancers.java
@@ -1,36 +1,33 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents LoadBalancers attributes
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public class LoadBalancers extends Base {
@@ -45,16 +42,12 @@ public class LoadBalancers extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the droplets
-   */
+  /** @return the droplets */
   public List<LoadBalancer> getLoadBalancers() {
     return loadBalancers;
   }
 
-  /**
-   * @param loadBalancers the droplets to set
-   */
+  /** @param loadBalancers the droplets to set */
   public void setLoadBalancers(List<LoadBalancer> loadBalancers) {
     this.loadBalancers = loadBalancers;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Meta.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Meta.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Meta attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Meta {
@@ -39,16 +37,12 @@ public class Meta {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the total
-   */
+  /** @return the total */
   public Integer getTotal() {
     return total;
   }
 
-  /**
-   * @param total the total to set
-   */
+  /** @param total the total to set */
   public void setTotal(Integer total) {
     this.total = total;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Neighbors.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Neighbors.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Neighbors attributes (which implicity refers droplet structure)
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Neighbors extends Base {
@@ -43,16 +40,12 @@ public class Neighbors extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the neighbors
-   */
+  /** @return the neighbors */
   public List<Droplet> getNeighbors() {
     return neighbors;
   }
 
-  /**
-   * @param neighbors the neighbors to set
-   */
+  /** @param neighbors the neighbors to set */
   public void setNeighbors(List<Droplet> neighbors) {
     this.neighbors = neighbors;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Network.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Network.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents DigitalOcean Network attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Network extends Base {
@@ -50,58 +47,42 @@ public class Network extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the ipAddress
-   */
+  /** @return the ipAddress */
   public String getIpAddress() {
     return ipAddress;
   }
 
-  /**
-   * @param ipAddress the ipAddress to set
-   */
+  /** @param ipAddress the ipAddress to set */
   public void setIpAddress(String ipAddress) {
     this.ipAddress = ipAddress;
   }
 
-  /**
-   * @return the netmask
-   */
+  /** @return the netmask */
   public String getNetmask() {
     return netmask;
   }
 
-  /**
-   * @param netmask the netmask to set
-   */
+  /** @param netmask the netmask to set */
   public void setNetmask(String netmask) {
     this.netmask = netmask;
   }
 
-  /**
-   * @return the gateway
-   */
+  /** @return the gateway */
   public String getGateway() {
     return gateway;
   }
 
-  /**
-   * @param gateway the gateway to set
-   */
+  /** @param gateway the gateway to set */
   public void setGateway(String gateway) {
     this.gateway = gateway;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public String getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(String type) {
     this.type = type;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Networks.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Networks.java
@@ -1,37 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents DigitalOcean Networks attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Networks {
@@ -47,30 +43,22 @@ public class Networks {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the version4Networks
-   */
+  /** @return the version4Networks */
   public List<Network> getVersion4Networks() {
     return version4Networks;
   }
 
-  /**
-   * @param version4Networks the version4Networks to set
-   */
+  /** @param version4Networks the version4Networks to set */
   public void setVersion4Networks(List<Network> version4Networks) {
     this.version4Networks = version4Networks;
   }
 
-  /**
-   * @return the version6Networks
-   */
+  /** @return the version6Networks */
   public List<Network> getVersion6Networks() {
     return version6Networks;
   }
 
-  /**
-   * @param version6Networks the version6Networks to set
-   */
+  /** @param version6Networks the version6Networks to set */
   public void setVersion6Networks(List<Network> version6Networks) {
     this.version6Networks = version6Networks;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/OutboundRules.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/OutboundRules.java
@@ -1,31 +1,29 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents OutboundRules for Firewalls
@@ -74,5 +72,4 @@ public class OutboundRules {
   public void setDestinations(Destinations destinations) {
     this.destinations = destinations;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Pages.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Pages.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Pages attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Pages {
@@ -45,58 +43,42 @@ public class Pages {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the first
-   */
+  /** @return the first */
   public String getFirst() {
     return first;
   }
 
-  /**
-   * @param first the first to set
-   */
+  /** @param first the first to set */
   public void setFirst(String first) {
     this.first = first;
   }
 
-  /**
-   * @return the prev
-   */
+  /** @return the prev */
   public String getPrev() {
     return prev;
   }
 
-  /**
-   * @param prev the prev to set
-   */
+  /** @param prev the prev to set */
   public void setPrev(String prev) {
     this.prev = prev;
   }
 
-  /**
-   * @return the next
-   */
+  /** @return the next */
   public String getNext() {
     return next;
   }
 
-  /**
-   * @param next the next to set
-   */
+  /** @param next the next to set */
   public void setNext(String next) {
     this.next = next;
   }
 
-  /**
-   * @return the last
-   */
+  /** @return the last */
   public String getLast() {
     return last;
   }
 
-  /**
-   * @param last the last to set
-   */
+  /** @param last the last to set */
   public void setLast(String last) {
     this.last = last;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/PendingChanges.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/PendingChanges.java
@@ -1,30 +1,28 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents PendingChanges for Firewalls
@@ -39,7 +37,7 @@ public class PendingChanges {
   private Boolean removing;
 
   private String status;
-  
+
   @Override
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
@@ -68,7 +66,4 @@ public class PendingChanges {
   public void setStatus(String status) {
     this.status = status;
   }
-
-
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/RateLimit.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/RateLimit.java
@@ -1,36 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.io.Serializable;
 import java.util.Date;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Rate Limit header values
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class RateLimit implements Serializable {
@@ -43,16 +40,14 @@ public class RateLimit implements Serializable {
 
   private Date reset;
 
-  /**
-   * Default Constructor
-   */
+  /** Default Constructor */
   public RateLimit() {
     // Default Constructor
   }
 
   /**
    * Parameterized Constructor
-   * 
+   *
    * @param limit the number of requests that can be made per hour
    * @param remaining the number of requests that remain before you hit your request limit
    * @param reset this represents the time when the oldest request will expire
@@ -68,23 +63,17 @@ public class RateLimit implements Serializable {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the limit
-   */
+  /** @return the limit */
   public Integer getLimit() {
     return limit;
   }
 
-  /**
-   * @return the remaining
-   */
+  /** @return the remaining */
   public Integer getRemaining() {
     return remaining;
   }
 
-  /**
-   * @return the reset
-   */
+  /** @return the reset */
   public Date getReset() {
     return reset;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/RateLimitBase.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/RateLimitBase.java
@@ -1,37 +1,33 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.io.Serializable;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents RateLimit header values and being extended in all POJO.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public abstract class RateLimitBase implements Serializable {
@@ -46,16 +42,12 @@ public abstract class RateLimitBase implements Serializable {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the rateLimit
-   */
+  /** @return the rateLimit */
   public RateLimit getRateLimit() {
     return rateLimit;
   }
 
-  /**
-   * @param rateLimit the rateLimit to set
-   */
+  /** @param rateLimit the rateLimit to set */
   public void setRateLimit(RateLimit rateLimit) {
     this.rateLimit = rateLimit;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Region.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Region.java
@@ -1,34 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Region (aka Data Center) attributes of DigitalOcean. Revised as per v2 API data
  * structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Region extends Base {
@@ -58,72 +56,52 @@ public class Region extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the slug
-   */
+  /** @return the slug */
   public String getSlug() {
     return slug;
   }
 
-  /**
-   * @param slug the slug to set
-   */
+  /** @param slug the slug to set */
   public void setSlug(String slug) {
     this.slug = slug;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the sizes
-   */
+  /** @return the sizes */
   public List<String> getSizes() {
     return sizes;
   }
 
-  /**
-   * @param sizes the sizes to set
-   */
+  /** @param sizes the sizes to set */
   public void setSizes(List<String> sizes) {
     this.sizes = sizes;
   }
 
-  /**
-   * @return the available
-   */
+  /** @return the available */
   public boolean isAvailable() {
     return available;
   }
 
-  /**
-   * @param available the available to set
-   */
+  /** @param available the available to set */
   public void setAvailable(boolean available) {
     this.available = available;
   }
 
-  /**
-   * @return the features
-   */
+  /** @return the features */
   public List<String> getFeatures() {
     return features;
   }
 
-  /**
-   * @param features the features to set
-   */
+  /** @param features the features to set */
   public void setFeatures(List<String> features) {
     this.features = features;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Regions.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Regions.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Regions attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Regions extends Base {
@@ -43,16 +40,12 @@ public class Regions extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the regions
-   */
+  /** @return the regions */
   public List<Region> getRegions() {
     return regions;
   }
 
-  /**
-   * @param regions the regions to set
-   */
+  /** @param regions the regions to set */
   public void setRegions(List<Region> regions) {
     this.regions = regions;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Resource.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Resource.java
@@ -1,37 +1,34 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.ResourceType;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Resource represent a single resource for associating/disassociating with tag on DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class Resource {
@@ -58,32 +55,23 @@ public class Resource {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public String getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(String id) {
     this.id = id;
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ResourceType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ResourceType type) {
     this.type = type;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Resources.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Resources.java
@@ -1,48 +1,43 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.Expose;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Resource represent a array of resources for associating/disassociating with tag on DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class Resources {
-  
-  @Expose
-  private List<Resource> resources;
-  
+
+  @Expose private List<Resource> resources;
+
   public Resources() {
     // Default Constructor
   }
-  
+
   public Resources(List<Resource> resources) {
     this.resources = resources;
   }
@@ -52,18 +47,13 @@ public class Resources {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the resources
-   */
+  /** @return the resources */
   public List<Resource> getResources() {
     return resources;
   }
 
-  /**
-   * @param resources the resources to set
-   */
+  /** @param resources the resources to set */
   public void setResources(List<Resource> resources) {
     this.resources = resources;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Response.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Response.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents generic basic response handling for HTTP Method
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class Response extends Base {
@@ -42,16 +39,14 @@ public class Response extends Base {
   @SerializedName("status_code")
   private int statusCode;
 
-  /**
-   * Default Constructor
-   */
+  /** Default Constructor */
   public Response() {
     // Default Constructor
   }
 
   /**
    * Parameterized Constructor
-   * 
+   *
    * @param isRequestSuccess whether delete is success or not
    */
   public Response(Boolean isRequestSuccess) {
@@ -63,30 +58,22 @@ public class Response extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the isRequestSuccess
-   */
+  /** @return the isRequestSuccess */
   public Boolean getIsRequestSuccess() {
     return isRequestSuccess;
   }
 
-  /**
-   * @param isRequestSuccess the isRequestSuccess to set
-   */
+  /** @param isRequestSuccess the isRequestSuccess to set */
   public void setIsRequestSuccess(Boolean isRequestSuccess) {
     this.isRequestSuccess = isRequestSuccess;
   }
 
-  /**
-   * @return the statusCode
-   */
+  /** @return the statusCode */
   public int getStatusCode() {
     return statusCode;
   }
 
-  /**
-   * @param statusCode the statusCode to set
-   */
+  /** @param statusCode the statusCode to set */
   public void setStatusCode(int statusCode) {
     this.statusCode = statusCode;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Size.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Size.java
@@ -1,37 +1,34 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
+import com.google.gson.annotations.SerializedName;
 import java.math.BigDecimal;
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
-import com.google.gson.annotations.SerializedName;
 
 /**
  * Represents Droplet Size (aka Droplet Plan) attributes of DigitalOcean. Revised as per v2 API data
  * structure.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class Size extends Base {
@@ -58,7 +55,7 @@ public class Size extends Base {
   private BigDecimal priceHourly;
 
   private List<String> regions;
-  
+
   private boolean available;
 
   public Size() {
@@ -74,129 +71,93 @@ public class Size extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the slug
-   */
+  /** @return the slug */
   public String getSlug() {
     return slug;
   }
 
-  /**
-   * @param slug the slug to set
-   */
+  /** @param slug the slug to set */
   public void setSlug(String slug) {
     this.slug = slug;
   }
 
-  /**
-   * @return the memorySizeInMb
-   */
+  /** @return the memorySizeInMb */
   public Integer getMemorySizeInMb() {
     return memorySizeInMb;
   }
 
-  /**
-   * @param memorySizeInMb the memorySizeInMb to set
-   */
+  /** @param memorySizeInMb the memorySizeInMb to set */
   public void setMemorySizeInMb(Integer memorySizeInMb) {
     this.memorySizeInMb = memorySizeInMb;
   }
 
-  /**
-   * @return the virutalCpuCount
-   */
+  /** @return the virutalCpuCount */
   public Integer getVirutalCpuCount() {
     return virutalCpuCount;
   }
 
-  /**
-   * @param virutalCpuCount the virutalCpuCount to set
-   */
+  /** @param virutalCpuCount the virutalCpuCount to set */
   public void setVirutalCpuCount(Integer virutalCpuCount) {
     this.virutalCpuCount = virutalCpuCount;
   }
 
-  /**
-   * @return the diskSize
-   */
+  /** @return the diskSize */
   public Integer getDiskSize() {
     return diskSize;
   }
 
-  /**
-   * @param diskSize the diskSize to set
-   */
+  /** @param diskSize the diskSize to set */
   public void setDiskSize(Integer diskSize) {
     this.diskSize = diskSize;
   }
 
-  /**
-   * @return the transfer
-   */
+  /** @return the transfer */
   public Long getTransfer() {
     return transfer;
   }
 
-  /**
-   * @param transfer the transfer to set
-   */
+  /** @param transfer the transfer to set */
   public void setTransfer(Long transfer) {
     this.transfer = transfer;
   }
 
-  /**
-   * @return the priceMonthly
-   */
+  /** @return the priceMonthly */
   public BigDecimal getPriceMonthly() {
     return priceMonthly;
   }
 
-  /**
-   * @param priceMonthly the priceMonthly to set
-   */
+  /** @param priceMonthly the priceMonthly to set */
   public void setPriceMonthly(BigDecimal priceMonthly) {
     this.priceMonthly = priceMonthly;
   }
 
-  /**
-   * @return the priceHourly
-   */
+  /** @return the priceHourly */
   public BigDecimal getPriceHourly() {
     return priceHourly;
   }
 
-  /**
-   * @param priceHourly the priceHourly to set
-   */
+  /** @param priceHourly the priceHourly to set */
   public void setPriceHourly(BigDecimal priceHourly) {
     this.priceHourly = priceHourly;
   }
 
-  /**
-   * @return the regions
-   */
+  /** @return the regions */
   public List<String> getRegions() {
     return regions;
   }
 
-  /**
-   * @param regions the regions to set
-   */
+  /** @param regions the regions to set */
   public void setRegions(List<String> regions) {
     this.regions = regions;
   }
 
-  /**
-   * @return the available
-   */
+  /** @return the available */
   public boolean isAvailable() {
     return available;
   }
 
-  /**
-   * @param available the available to set
-   */
+  /** @param available the available to set */
   public void setAvailable(boolean available) {
     this.available = available;
-  }  
+  }
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Sizes.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Sizes.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Sizes attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Sizes extends Base {
@@ -43,16 +40,12 @@ public class Sizes extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the sizes
-   */
+  /** @return the sizes */
   public List<Size> getSizes() {
     return sizes;
   }
 
-  /**
-   * @param sizes the sizes to set
-   */
+  /** @param sizes the sizes to set */
   public void setSizes(List<Size> sizes) {
     this.sizes = sizes;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Snapshot.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Snapshot.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 /**
  * Represents Snapshot attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v1.4
  */
 public class Snapshot extends Image {
 
   private static final long serialVersionUID = 5713559939273842460L;
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Snapshots.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Snapshots.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
 
 /**
  * Represents Snapshots attributes
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class Snapshots extends Base {
@@ -36,16 +34,12 @@ public class Snapshots extends Base {
 
   List<Snapshot> snapshots;
 
-  /**
-   * @return the snapshots
-   */
+  /** @return the snapshots */
   public List<Snapshot> getSnapshots() {
     return snapshots;
   }
 
-  /**
-   * @param snapshots the snapshots to set
-   */
+  /** @param snapshots the snapshots to set */
   public void setSnapshots(List<Snapshot> snapshots) {
     this.snapshots = snapshots;
   }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Sources.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Sources.java
@@ -1,33 +1,30 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Sources for InboundRules used by Firewalls
@@ -36,8 +33,7 @@ import com.google.gson.annotations.SerializedName;
  */
 public class Sources {
 
-  @Expose
-  private List<String> addresses;
+  @Expose private List<String> addresses;
 
   @Expose
   @SerializedName("droplet_ids")
@@ -87,5 +83,4 @@ public class Sources {
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/StickySessions.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/StickySessions.java
@@ -1,24 +1,23 @@
 /**
  * The MIT License
  *
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import com.google.gson.annotations.Expose;
@@ -30,18 +29,15 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
  * Represents DigitalOcean Load Balancer sticky sessions object
  *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- *
  * @since v2.11
  */
 public class StickySessions extends Base {
 
   private static final long serialVersionUID = -2697068548366505704L;
 
-  @Expose
-  private StickySessionType type = StickySessionType.None;
+  @Expose private StickySessionType type = StickySessionType.None;
 
-  @Expose
-  private Integer port;
+  @Expose private Integer port;
 
   @Expose
   @SerializedName("cookie_name")
@@ -56,46 +52,33 @@ public class StickySessions extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public StickySessionType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(StickySessionType type) {
     this.type = type;
   }
 
-  /**
-   * @return the cookie name
-   */
+  /** @return the cookie name */
   public String getCookieName() {
     return cookieName;
   }
 
-  /**
-   * @param cookieName the cookie name to set
-   */
+  /** @param cookieName the cookie name to set */
   public void setCookieName(String cookieName) {
     this.cookieName = cookieName;
   }
 
-  /**
-   * @return the cookie TTL in seconds
-   */
+  /** @return the cookie TTL in seconds */
   public Integer getCookieTtlInSeconds() {
     return cookieTtlInSeconds;
   }
 
-  /**
-   * @param cookieTtlInSeconds the cookie TTL in seconds to set
-   */
+  /** @param cookieTtlInSeconds the cookie TTL in seconds to set */
   public void setCookieTtlInSeconds(Integer cookieTtlInSeconds) {
     this.cookieTtlInSeconds = cookieTtlInSeconds;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Tag.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Tag.java
@@ -1,44 +1,40 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.Expose;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Tag attributes of DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class Tag extends Base {
 
   private static final long serialVersionUID = -5828623466026614221L;
 
-  @Expose
-  private String name;
-  
+  @Expose private String name;
+
   private TagResource resources;
 
   public Tag() {
@@ -48,38 +44,29 @@ public class Tag extends Base {
   public Tag(String name) {
     this.name = name;
   }
-  
+
   @Override
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the resources
-   */
+  /** @return the resources */
   public TagResource getResources() {
     return resources;
   }
 
-  /**
-   * @param resources the resources to set
-   */
+  /** @param resources the resources to set */
   public void setResources(TagResource resources) {
     this.resources = resources;
   }
-  
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/TagDropletResource.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/TagDropletResource.java
@@ -1,41 +1,38 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents the droplet resource a tag is attached on DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class TagDropletResource {
 
   private int count;
-  
+
   @SerializedName("last_tagged_uri")
   private String lastTaggedUri;
 
@@ -48,52 +45,43 @@ public class TagDropletResource {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the count
-   */
+  /** @return the count */
   public int getCount() {
     return count;
   }
 
-  /**
-   * @param count the count to set
-   */
+  /** @param count the count to set */
   public void setCount(int count) {
     this.count = count;
   }
 
-  /**
-   * @return the lastTaggedUri
-   */
+  /** @return the lastTaggedUri */
   public String getLastTaggedUri() {
     return lastTaggedUri;
   }
 
-  /**
-   * @param lastTaggedUri the lastTaggedUri to set
-   */
+  /** @param lastTaggedUri the lastTaggedUri to set */
   public void setLastTaggedUri(String lastTaggedUri) {
     this.lastTaggedUri = lastTaggedUri;
   }
 
   /**
    * @return the lastTagged
-   * 
-   * <p>Deprecated: https://developers.digitalocean.com/documentation/changelog/api-v2/adding-tagged-uri/</p>
+   *     <p>Deprecated:
+   *     https://developers.digitalocean.com/documentation/changelog/api-v2/adding-tagged-uri/
    */
-  @Deprecated 
+  @Deprecated
   public Droplet getLastTagged() {
     return lastTagged;
   }
 
   /**
    * @param lastTagged the lastTagged to set
-   * 
-   * <p>Deprecated: https://developers.digitalocean.com/documentation/changelog/api-v2/adding-tagged-uri/</p>
+   *     <p>Deprecated:
+   *     https://developers.digitalocean.com/documentation/changelog/api-v2/adding-tagged-uri/
    */
   @Deprecated
   public void setLastTagged(Droplet lastTagged) {
     this.lastTagged = lastTagged;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/TagResource.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/TagResource.java
@@ -1,33 +1,31 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * TagResource represent the set of resources a tag is attached on DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class TagResource {
@@ -39,18 +37,13 @@ public class TagResource {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the droplets
-   */
+  /** @return the droplets */
   public TagDropletResource getDroplets() {
     return droplets;
   }
 
-  /**
-   * @param droplets the droplets to set
-   */
+  /** @param droplets the droplets to set */
   public void setDroplets(TagDropletResource droplets) {
     this.droplets = droplets;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Tags.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Tags.java
@@ -1,35 +1,32 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents Tag attributes of DigitalOcean.
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.5
  */
 public class Tags extends Base {
@@ -43,18 +40,13 @@ public class Tags extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the tags
-   */
+  /** @return the tags */
   public List<Tag> getTags() {
     return tags;
   }
 
-  /**
-   * @param tags the tags to set
-   */
+  /** @param tags the tags to set */
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Volume.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Volume.java
@@ -1,29 +1,23 @@
 /**
  * Copyright (c) Jeevanandam M. (https://github.com/jeevatkm)
- * 
- * digitalocean-api-client source code and usage is governed by a MIT style license that can be
+ *
+ * <p>digitalocean-api-client source code and usage is governed by a MIT style license that can be
  * found in the LICENSE file
  */
-
 package com.myjeeva.digitalocean.pojo;
 
+import com.google.gson.annotations.SerializedName;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-
-import com.google.gson.annotations.SerializedName;
 
 /**
  * Represents Block Storage attributes of DigitalOcean.
- * 
- * <p>
- * Block Storage volumes provide expanded storage capacity for your Droplets.
- * </p>
- * 
+ *
+ * <p>Block Storage volumes provide expanded storage capacity for your Droplets.
+ *
  * @author Eugene Strokin (https://github.com/strokine)
- * 
  * @since v2.7
  */
 public class Volume extends Base {
@@ -49,13 +43,13 @@ public class Volume extends Base {
 
   @SerializedName("snapshot_id")
   private String snapshotId;
-  
+
   @SerializedName("filesystem_type")
   private String fileSystemType;
-  
+
   @SerializedName("filesystem_label")
   private String fileSystemLabel;
-  
+
   private List<String> tags;
 
   @Override
@@ -63,158 +57,113 @@ public class Volume extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the id
-   */
+  /** @return the id */
   public String getId() {
     return id;
   }
 
-  /**
-   * @param id the id to set
-   */
+  /** @param id the id to set */
   public void setId(String id) {
     this.id = id;
   }
 
-  /**
-   * @return the region
-   */
+  /** @return the region */
   public Region getRegion() {
     return region;
   }
 
-  /**
-   * @param region the region to set
-   */
+  /** @param region the region to set */
   public void setRegion(Region region) {
     this.region = region;
   }
 
-  /**
-   * @return the dropletIds
-   */
+  /** @return the dropletIds */
   public Set<Integer> getDropletIds() {
     return dropletIds;
   }
 
-  /**
-   * @param dropletIds the dropletIds to set
-   */
+  /** @param dropletIds the dropletIds to set */
   public void setDropletIds(Set<Integer> dropletIds) {
     this.dropletIds = dropletIds;
   }
 
-  /**
-   * @return the name
-   */
+  /** @return the name */
   public String getName() {
     return name;
   }
 
-  /**
-   * @param name the name to set
-   */
+  /** @param name the name to set */
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * @return the description
-   */
+  /** @return the description */
   public String getDescription() {
     return description;
   }
 
-  /**
-   * @param description the description to set
-   */
+  /** @param description the description to set */
   public void setDescription(String description) {
     this.description = description;
   }
 
-  /**
-   * @return the size in Gigabytes
-   */
+  /** @return the size in Gigabytes */
   public Integer getSize() {
     return size;
   }
 
-  /**
-   * @param size the size to set
-   */
+  /** @param size the size to set */
   public void setSize(Integer size) {
     this.size = size;
   }
 
-  /**
-   * @return the createdDate
-   */
+  /** @return the createdDate */
   public Date getCreatedDate() {
     return createdDate;
   }
 
-  /**
-   * @param createdDate the createdDate to set
-   */
+  /** @param createdDate the createdDate to set */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
-  /**
-   * @return the snapshotId
-   */
+  /** @return the snapshotId */
   public String getSnapshotId() {
     return snapshotId;
   }
 
-  /**
-   * @param snapshotId the snapshotId to set
-   */
+  /** @param snapshotId the snapshotId to set */
   public void setSnapshotId(String snapshotId) {
     this.snapshotId = snapshotId;
   }
 
-  /**
-   * @return the fileSystemType
-   */
+  /** @return the fileSystemType */
   public String getFileSystemType() {
     return fileSystemType;
   }
 
-  /**
-   * @param fileSystemType the fileSystemType to set
-   */
+  /** @param fileSystemType the fileSystemType to set */
   public void setFileSystemType(String fileSystemType) {
     this.fileSystemType = fileSystemType;
   }
 
-  /**
-   * @return the fileSystemLabel
-   */
+  /** @return the fileSystemLabel */
   public String getFileSystemLabel() {
     return fileSystemLabel;
   }
 
-  /**
-   * @param fileSystemLabel the fileSystemLabel to set
-   */
+  /** @param fileSystemLabel the fileSystemLabel to set */
   public void setFileSystemLabel(String fileSystemLabel) {
     this.fileSystemLabel = fileSystemLabel;
   }
 
-  /**
-   * @return the tags
-   */
+  /** @return the tags */
   public List<String> getTags() {
     return tags;
   }
 
-  /**
-   * @param tags the tags to set
-   */
+  /** @param tags the tags to set */
   public void setTags(List<String> tags) {
     this.tags = tags;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/VolumeAction.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/VolumeAction.java
@@ -1,29 +1,25 @@
 /**
  * Copyright (c) Jeevanandam M. (https://github.com/jeevatkm)
- * 
- * digitalocean-api-client source code and usage is governed by a MIT style license that can be
+ *
+ * <p>digitalocean-api-client source code and usage is governed by a MIT style license that can be
  * found in the LICENSE file
  */
-
 package com.myjeeva.digitalocean.pojo;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.myjeeva.digitalocean.common.ActionType;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Volume action is to create new volume.
- * 
+ *
  * @author Eugene Strokin (https://github.com/strokine)
- * 
  * @since v2.7
  */
 public class VolumeAction {
 
-  @Expose
-  private ActionType type;
+  @Expose private ActionType type;
 
   @Expose
   @SerializedName("droplet_id")
@@ -41,16 +37,14 @@ public class VolumeAction {
   @SerializedName("size_gigabytes")
   private Double size;
 
-  /**
-   * Constructor
-   */
+  /** Constructor */
   public VolumeAction() {
     // Default Constructor
   }
 
   /**
    * Constructor
-   * 
+   *
    * @param type action type of the volume
    * @param dropletId is to attach/detach volume from droplet
    * @param regionSlug short name of region
@@ -61,7 +55,7 @@ public class VolumeAction {
 
   /**
    * Constructor
-   * 
+   *
    * @param type action type of the volume
    * @param regionSlug short name of region
    * @param size volume size in GB
@@ -72,15 +66,15 @@ public class VolumeAction {
 
   /**
    * Constructor
-   * 
+   *
    * @param type action type of the volume
    * @param dropletId is to attach/detach volume from droplet
    * @param regionSlug short name of region
    * @param volumeName
    * @param size volume size in GB
    */
-  public VolumeAction(ActionType type, Integer dropletId, String regionSlug, String volumeName,
-      Double size) {
+  public VolumeAction(
+      ActionType type, Integer dropletId, String regionSlug, String volumeName, Double size) {
     this.type = type;
     this.dropletId = dropletId;
     this.regionSlug = regionSlug;
@@ -93,74 +87,53 @@ public class VolumeAction {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the type
-   */
+  /** @return the type */
   public ActionType getType() {
     return type;
   }
 
-  /**
-   * @param type the type to set
-   */
+  /** @param type the type to set */
   public void setType(ActionType type) {
     this.type = type;
   }
 
-  /**
-   * @return the dropletId
-   */
+  /** @return the dropletId */
   public Integer getDropletId() {
     return dropletId;
   }
 
-  /**
-   * @param dropletId the dropletId to set
-   */
+  /** @param dropletId the dropletId to set */
   public void setDropletId(Integer dropletId) {
     this.dropletId = dropletId;
   }
 
-  /**
-   * @return the regionSlug
-   */
+  /** @return the regionSlug */
   public String getRegionSlug() {
     return regionSlug;
   }
 
-  /**
-   * @param regionSlug the regionSlug to set
-   */
+  /** @param regionSlug the regionSlug to set */
   public void setRegionSlug(String regionSlug) {
     this.regionSlug = regionSlug;
   }
 
-  /**
-   * @return the volumeName
-   */
+  /** @return the volumeName */
   public String getVolumeName() {
     return volumeName;
   }
 
-  /**
-   * @param volumeName the volumeName to set
-   */
+  /** @param volumeName the volumeName to set */
   public void setVolumeName(String volumeName) {
     this.volumeName = volumeName;
   }
 
-  /**
-   * @return the size
-   */
+  /** @return the size */
   public Double getSize() {
     return size;
   }
 
-  /**
-   * @param size the size to set
-   */
+  /** @param size the size to set */
   public void setSize(Double size) {
     this.size = size;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/pojo/Volumes.java
+++ b/src/main/java/com/myjeeva/digitalocean/pojo/Volumes.java
@@ -1,21 +1,18 @@
 /**
  * Copyright (c) Jeevanandam M. (https://github.com/jeevatkm)
- * 
- * digitalocean-api-client source code and usage is governed by a MIT style license that can be
+ *
+ * <p>digitalocean-api-client source code and usage is governed by a MIT style license that can be
  * found in the LICENSE file
  */
-
 package com.myjeeva.digitalocean.pojo;
 
 import java.util.List;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 /**
  * Represents list of volumes.
- * 
+ *
  * @author Eugene Strokin (https://github.com/strokine)
- * 
  * @since v2.7
  */
 public class Volumes extends Base {
@@ -29,18 +26,13 @@ public class Volumes extends Base {
     return ReflectionToStringBuilder.toString(this);
   }
 
-  /**
-   * @return the volumes
-   */
+  /** @return the volumes */
   public List<Volume> getVolumes() {
     return volumes;
   }
 
-  /**
-   * @param volumes the volumes to set
-   */
+  /** @param volumes the volumes to set */
   public void setVolumes(List<Volume> volumes) {
     this.volumes = volumes;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/serializer/DropletSerializer.java
+++ b/src/main/java/com/myjeeva/digitalocean/serializer/DropletSerializer.java
@@ -1,29 +1,24 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.serializer;
-
-import java.lang.reflect.Type;
-
-import org.apache.commons.lang3.StringUtils;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -32,12 +27,13 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.myjeeva.digitalocean.pojo.Droplet;
 import com.myjeeva.digitalocean.pojo.Key;
+import java.lang.reflect.Type;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Serializer for droplet class
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
- * 
  * @since v2.0
  */
 public class DropletSerializer implements JsonSerializer<Droplet> {
@@ -120,5 +116,4 @@ public class DropletSerializer implements JsonSerializer<Droplet> {
 
     return jsonObject;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/serializer/FirewallSerializer.java
+++ b/src/main/java/com/myjeeva/digitalocean/serializer/FirewallSerializer.java
@@ -1,28 +1,25 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- *               2018 Lucas Andrey B. (andreybleme1@gmail.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com) 2018 Lucas Andrey B.
+ * (andreybleme1@gmail.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package com.myjeeva.digitalocean.serializer;
-
-import java.lang.reflect.Type;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -32,19 +29,19 @@ import com.google.gson.JsonSerializer;
 import com.myjeeva.digitalocean.pojo.Firewall;
 import com.myjeeva.digitalocean.pojo.InboundRules;
 import com.myjeeva.digitalocean.pojo.OutboundRules;
+import java.lang.reflect.Type;
 
 /**
  * Serializer for firewall class
- * 
+ *
  * @author Lucas Andrey B. (andreybleme1@gmail.com)
- * 
  * @since v2.16
  */
 public class FirewallSerializer implements JsonSerializer<Firewall> {
 
   @Override
-  public JsonElement serialize(Firewall firewall, Type paramType,
-      JsonSerializationContext context) {
+  public JsonElement serialize(
+      Firewall firewall, Type paramType, JsonSerializationContext context) {
     final JsonObject jsonObject = new JsonObject();
 
     jsonObject.addProperty("name", firewall.getName());
@@ -83,5 +80,4 @@ public class FirewallSerializer implements JsonSerializer<Firewall> {
 
     return jsonObject;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/serializer/LoadBalancerSerializer.java
+++ b/src/main/java/com/myjeeva/digitalocean/serializer/LoadBalancerSerializer.java
@@ -1,13 +1,10 @@
 /**
  * Copyright (c) Jeevanandam M. (https://github.com/jeevatkm)
- * 
- * digitalocean-api-client source code and usage is governed by a MIT style license that can be
+ *
+ * <p>digitalocean-api-client source code and usage is governed by a MIT style license that can be
  * found in the LICENSE file
  */
-
 package com.myjeeva.digitalocean.serializer;
-
-import java.lang.reflect.Type;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -16,19 +13,19 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.myjeeva.digitalocean.pojo.ForwardingRules;
 import com.myjeeva.digitalocean.pojo.LoadBalancer;
+import java.lang.reflect.Type;
 
 /**
  * Serialize the load balancer info for POST request.
- * 
+ *
  * @author Thomas Lehoux (https://github.com/tlehoux)
- * 
  * @since v2.11
  */
 public class LoadBalancerSerializer implements JsonSerializer<LoadBalancer> {
 
   @Override
-  public JsonElement serialize(LoadBalancer loadBalancer, Type paramType,
-      JsonSerializationContext context) {
+  public JsonElement serialize(
+      LoadBalancer loadBalancer, Type paramType, JsonSerializationContext context) {
     final JsonObject jsonObject = new JsonObject();
 
     jsonObject.addProperty("name", loadBalancer.getName());
@@ -64,5 +61,4 @@ public class LoadBalancerSerializer implements JsonSerializer<LoadBalancer> {
     }
     return jsonObject;
   }
-
 }

--- a/src/main/java/com/myjeeva/digitalocean/serializer/VolumeSerializer.java
+++ b/src/main/java/com/myjeeva/digitalocean/serializer/VolumeSerializer.java
@@ -1,15 +1,10 @@
 /**
  * Copyright (c) Jeevanandam M. (https://github.com/jeevatkm)
- * 
- * digitalocean-api-client source code and usage is governed by a MIT style license that can be
+ *
+ * <p>digitalocean-api-client source code and usage is governed by a MIT style license that can be
  * found in the LICENSE file
  */
-
 package com.myjeeva.digitalocean.serializer;
-
-import java.lang.reflect.Type;
-
-import org.apache.commons.lang3.StringUtils;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -17,12 +12,13 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.myjeeva.digitalocean.pojo.Volume;
+import java.lang.reflect.Type;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Serialize the volume info for POST request.
- * 
+ *
  * @author Eugene Strokin (https://github.com/strokine)
- * 
  * @since v2.7
  */
 public class VolumeSerializer implements JsonSerializer<Volume> {
@@ -71,5 +67,4 @@ public class VolumeSerializer implements JsonSerializer<Volume> {
 
     return jsonObject;
   }
-
 }

--- a/src/test/java/com/myjeeva/digitalocean/DigitalOceanIntegrationTest.java
+++ b/src/test/java/com/myjeeva/digitalocean/DigitalOceanIntegrationTest.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -24,17 +24,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.myjeeva.digitalocean.common.ActionType;
 import com.myjeeva.digitalocean.common.LoadBalancingAlgorithm;
@@ -90,17 +79,22 @@ import com.myjeeva.digitalocean.pojo.Tag;
 import com.myjeeva.digitalocean.pojo.Tags;
 import com.myjeeva.digitalocean.pojo.Volume;
 import com.myjeeva.digitalocean.pojo.Volumes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * <p>
  * Junit Integration Test case for DigitalOcean API client wrapper methods
- * </p>
- * 
- * <p>
- * <strong>Please Note:</strong> <i>Kindly through and update private variable value before using
+ *
+ * <p><strong>Please Note:</strong> <i>Kindly through and update private variable value before using
  * executing this test case(s).</i>
- * </p>
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 // Marked as Ignore since its a Integration Test case with real values
@@ -115,16 +109,19 @@ public class DigitalOceanIntegrationTest {
    * with API. So place your's for integration test case before use
    */
   private String authTokenRW = "";
+
   private Integer dropletIdForInfo = 10001; // to be placed before use
   private String volumeIdForInfo = "10001"; // to be placed before use
   private String volumeNameForInfo = "test-volume"; // to be placed before use, should have
-                                                    // different ID from volumeIdForInfo and created
-                                                    // in nyc1 region
-  private String volumeSnapshotIdForCreate = "197e26b6-c242-11e7-bd8b-0242ac113802"; // to be placed before use
+  // different ID from volumeIdForInfo and created
+  // in nyc1 region
+  private String volumeSnapshotIdForCreate =
+      "197e26b6-c242-11e7-bd8b-0242ac113802"; // to be placed before use
   private String loadBalancerIdForInfo = "155fa6cd-3e74-406d-90bd-5671488c7157"; // to be placed
-                                                                                 // before use
-  private String firewallIdForInfo = "190ceeb7-779a-4b04-9091-4dd175de65ec"; // to be placed before use
-  
+  // before use
+  private String firewallIdForInfo =
+      "190ceeb7-779a-4b04-9091-4dd175de65ec"; // to be placed before use
+
   private Integer imageId = 3445812; // Debian 7.0 x64 image id
   private String imageSlug = "ubuntu-12-04-x64";
   private String domainName = "";
@@ -164,8 +161,7 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetDropletSnapshots() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetDropletSnapshots() throws DigitalOceanException, RequestUnsuccessfulException {
 
     Snapshots snapshots = apiClient.getDropletSnapshots(dropletIdForInfo, 1, 20);
 
@@ -201,8 +197,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateDropletByImageId() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateDropletByImageId()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Droplet droplet = new Droplet();
     droplet.setName("api-client-test-host-byid");
@@ -235,8 +231,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateDropletByImageSlug() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateDropletByImageSlug()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Droplet droplet = new Droplet();
     droplet.setName("api-client-test-host-byslug1");
@@ -261,8 +257,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateDropletsByImageSlug() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateDropletsByImageSlug()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Droplet droplet = new Droplet();
     droplet.setNames(Arrays.asList("sub-01.example.com", "sub-02.example.com"));
@@ -313,8 +309,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAllDropletNeighbors() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAllDropletNeighbors()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Neighbors neighbors = apiClient.getAllDropletNeighbors(1);
 
@@ -324,10 +320,10 @@ public class DigitalOceanIntegrationTest {
       log.info(d.toString());
     }
   }
-  
+
   @Test
-  public void testGetAvailableDropletsByTagName() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableDropletsByTagName()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Droplets droplets = apiClient.getAvailableDropletsByTagName("mytagtest1", 1, 25);
 
@@ -441,8 +437,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testDisableDropletBackups() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testDisableDropletBackups()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Action action = apiClient.disableDropletBackups(2258168);
 
@@ -478,8 +474,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testEnableDropletPrivateNetworking() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testEnableDropletPrivateNetworking()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Action action = apiClient.enableDropletPrivateNetworking(2258168);
 
@@ -525,8 +521,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableDropletActions() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableDropletActions()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Actions actions = apiClient.getAvailableDropletActions(dropletIdForInfo, 1, 20);
     Actions actions3 = apiClient.getAvailableDropletActions(dropletIdForInfo, 3, 20);
@@ -543,8 +539,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableImageActions() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableImageActions()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Actions actions = apiClient.getAvailableImageActions(3794738, 1, 20);
 
@@ -557,8 +553,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableFloatingIPActions() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableFloatingIPActions()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     Actions actions = apiClient.getAvailableFloatingIPActions("159.203.146.100", 1, 10);
 
     log.info(actions.toString());
@@ -572,8 +568,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetFloatingIPActionInfo() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetFloatingIPActionInfo()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     Action action = apiClient.getFloatingIPActionInfo("159.203.146.100", 76697074);
 
     log.info(action.toString());
@@ -597,8 +593,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableImagesByDistribution() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableImagesByDistribution()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Images images = apiClient.getAvailableImages(1, 20, ActionType.DISTRIBUTION);
 
@@ -611,8 +607,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableImagesByApplication() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableImagesByApplication()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Images images = apiClient.getAvailableImages(1, 20, ActionType.APPLICATION);
 
@@ -625,8 +621,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableImagesByIncorrrect() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableImagesByIncorrrect()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     try {
       apiClient.getAvailableImages(1, 20, ActionType.BACKUP);
     } catch (DigitalOceanException doe) {
@@ -666,16 +662,19 @@ public class DigitalOceanIntegrationTest {
 
     log.info(image.toString());
   }
-  
+
   @Test
   public void testCreateCustomImage() throws DigitalOceanException, RequestUnsuccessfulException {
 
-    Image input = new Image("ubuntu-18.04-minimal", "http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img"
-        , "nyc3");
+    Image input =
+        new Image(
+            "ubuntu-18.04-minimal",
+            "http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img",
+            "nyc3");
     input.setDescription("Cloud-optimized image w/ small footprint");
     input.setDistribution("Ubuntu");
     input.setTags(Arrays.asList("base-image", "prod"));
-    
+
     Image image = apiClient.updateImage(input);
 
     assertNotNull(image);
@@ -904,8 +903,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testUpdateKeyByFingerprint() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testUpdateKeyByFingerprint()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     Key resultKey =
         apiClient.updateKey("3b:0b:99:54:ef:75:cb:88:88:66:3c:8d:10:64:74:32", "TestKey4");
 
@@ -923,8 +922,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testDeleteKeyByFingerprint() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testDeleteKeyByFingerprint()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     Delete result = apiClient.deleteKey("3b:0b:99:54:ef:75:cb:88:88:66:3c:8d:10:64:74:32");
 
     assertNotNull(result);
@@ -933,8 +932,8 @@ public class DigitalOceanIntegrationTest {
 
   // Floating IPs test cases
   @Test
-  public void testGetAvailableFloatingIPs() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableFloatingIPs()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     FloatingIPs floatingIPs = apiClient.getAvailableFloatingIPs(1, 10);
 
@@ -950,8 +949,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateFloatingIPForDroplet() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateFloatingIPForDroplet()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     FloatingIP floatingIP = apiClient.createFloatingIP(9674996);
 
@@ -961,8 +960,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateFloatingIPForRegion() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateFloatingIPForRegion()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     FloatingIP floatingIP = apiClient.createFloatingIP("nyc3");
 
@@ -972,8 +971,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetFloatingIPInfo(String ipAddress) throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetFloatingIPInfo(String ipAddress)
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     FloatingIP floatingIP = apiClient.getFloatingIPInfo("159.203.146.100");
 
@@ -1206,8 +1205,7 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetVolumeSnapshots() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetVolumeSnapshots() throws DigitalOceanException, RequestUnsuccessfulException {
 
     Snapshots snapshots =
         apiClient.getVolumeSnapshots("82a48a18-873f-11e6-96bf-000f53315a41", 1, 10);
@@ -1222,8 +1220,9 @@ public class DigitalOceanIntegrationTest {
 
   @Test
   public void testTakeVolumeSnapshot() throws DigitalOceanException, RequestUnsuccessfulException {
-    Snapshot snapshot = apiClient.takeVolumeSnapshot("fbe805e8-866b-11e6-96bf-000f53315a41",
-        "api-test-volume-snapshot");
+    Snapshot snapshot =
+        apiClient.takeVolumeSnapshot(
+            "fbe805e8-866b-11e6-96bf-000f53315a41", "api-test-volume-snapshot");
 
     assertNotNull(snapshot);
 
@@ -1231,8 +1230,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAvailableSnapshots() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAvailableSnapshots()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Snapshots snapshots = apiClient.getAvailableSnapshots(1, 10);
 
@@ -1245,8 +1244,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAllDropletSnapshots() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAllDropletSnapshots()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Snapshots snapshots = apiClient.getAllDropletSnapshots(1, 10);
 
@@ -1259,8 +1258,8 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testGetAllVolumeSnapshots() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testGetAllVolumeSnapshots()
+      throws DigitalOceanException, RequestUnsuccessfulException {
 
     Snapshots snapshots = apiClient.getAllVolumeSnapshots(1, 10);
 
@@ -1290,8 +1289,7 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testCreateLoadBalancer() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testCreateLoadBalancer() throws DigitalOceanException, RequestUnsuccessfulException {
 
     LoadBalancer loadBalancer = new LoadBalancer();
     loadBalancer.setName("api-client-test-loadbalancer");
@@ -1324,8 +1322,7 @@ public class DigitalOceanIntegrationTest {
   }
 
   @Test
-  public void testUpdateLoadBalancer() throws DigitalOceanException,
-      RequestUnsuccessfulException {
+  public void testUpdateLoadBalancer() throws DigitalOceanException, RequestUnsuccessfulException {
 
     LoadBalancer lb = apiClient.getLoadBalancerInfo(loadBalancerIdForInfo);
     lb.setAlgorithm(LoadBalancingAlgorithm.LEAST_CONNECTIONS);
@@ -1376,8 +1373,9 @@ public class DigitalOceanIntegrationTest {
   public void testRemoveDropletsFromLoadBalancer()
       throws DigitalOceanException, RequestUnsuccessfulException {
 
-    Delete result = apiClient.removeDropletsFromLoadBalancer(loadBalancerIdForInfo,
-        Arrays.asList(dropletIdForInfo));
+    Delete result =
+        apiClient.removeDropletsFromLoadBalancer(
+            loadBalancerIdForInfo, Arrays.asList(dropletIdForInfo));
     assertNotNull(result);
   }
 
@@ -1394,7 +1392,6 @@ public class DigitalOceanIntegrationTest {
     Response result =
         apiClient.addForwardingRulesToLoadBalancer(loadBalancerIdForInfo, Arrays.asList(rule));
     assertNotNull(result);
-
   }
 
   @Test
@@ -1410,12 +1407,10 @@ public class DigitalOceanIntegrationTest {
     Response result =
         apiClient.removeForwardingRulesFromLoadBalancer(loadBalancerIdForInfo, Arrays.asList(rule));
     assertNotNull(result);
-
   }
 
   @Test
-  public void testDeleteLoadBalancer()
-      throws DigitalOceanException, RequestUnsuccessfulException {
+  public void testDeleteLoadBalancer() throws DigitalOceanException, RequestUnsuccessfulException {
 
     Delete result = apiClient.deleteLoadBalancer(loadBalancerIdForInfo);
     assertNotNull(result);
@@ -1446,11 +1441,12 @@ public class DigitalOceanIntegrationTest {
 
     log.info(result.toString());
   }
-  
-  @Test
-  public void testLetsEncryptCreateCertificate() throws DigitalOceanException, RequestUnsuccessfulException {
 
-    String[] dnsNames = { "example.com", "www.example.com"};
+  @Test
+  public void testLetsEncryptCreateCertificate()
+      throws DigitalOceanException, RequestUnsuccessfulException {
+
+    String[] dnsNames = {"example.com", "www.example.com"};
     Certificate certificate =
         new Certificate("my-let-encrypt-cert", "lets_encrypt", Arrays.asList(dnsNames));
 
@@ -1475,42 +1471,42 @@ public class DigitalOceanIntegrationTest {
     assertNotNull(result);
     log.info("Delete Request Object: " + result);
   }
-  
+
   @Test
   public void testCreateFirewall() throws DigitalOceanException, RequestUnsuccessfulException {
-	List<String> addressesInbound = Arrays.asList("18.0.0.0/8");
-	
-	Sources sources = new Sources();
-	sources.setAddresses(addressesInbound);
-	
-	InboundRules inboundRules = new InboundRules();
-	inboundRules.setProtocol("tcp");
-	inboundRules.setPorts("22");
-	inboundRules.setSources(sources);
-	
-	List<String> addressesOutbound = Arrays.asList("0.0.0.0/0", "::/0");
-	
-	Destinations destinations = new Destinations();
-	destinations.setAddresses(addressesOutbound);
-	
-	OutboundRules outboundRules = new OutboundRules();
-	outboundRules.setProtocol("tcp");
-	outboundRules.setPorts("80");
-	outboundRules.setDestinations(destinations);
-	
-	Firewall firewall = new Firewall();
-	firewall.setName("integration-firewall");
-	firewall.setInboundRules(Arrays.asList(inboundRules));
-	firewall.setOutboundRules(Arrays.asList(outboundRules));
-	
-	Firewall fw = apiClient.createFirewall(firewall);
-	
-	assertNotNull(fw);
-	assertNotNull(fw.getId());
-	
-	log.info(fw.toString());
+    List<String> addressesInbound = Arrays.asList("18.0.0.0/8");
+
+    Sources sources = new Sources();
+    sources.setAddresses(addressesInbound);
+
+    InboundRules inboundRules = new InboundRules();
+    inboundRules.setProtocol("tcp");
+    inboundRules.setPorts("22");
+    inboundRules.setSources(sources);
+
+    List<String> addressesOutbound = Arrays.asList("0.0.0.0/0", "::/0");
+
+    Destinations destinations = new Destinations();
+    destinations.setAddresses(addressesOutbound);
+
+    OutboundRules outboundRules = new OutboundRules();
+    outboundRules.setProtocol("tcp");
+    outboundRules.setPorts("80");
+    outboundRules.setDestinations(destinations);
+
+    Firewall firewall = new Firewall();
+    firewall.setName("integration-firewall");
+    firewall.setInboundRules(Arrays.asList(inboundRules));
+    firewall.setOutboundRules(Arrays.asList(outboundRules));
+
+    Firewall fw = apiClient.createFirewall(firewall);
+
+    assertNotNull(fw);
+    assertNotNull(fw.getId());
+
+    log.info(fw.toString());
   }
-  
+
   @Test
   public void testGetFirewallInfo() throws DigitalOceanException, RequestUnsuccessfulException {
 
@@ -1518,38 +1514,38 @@ public class DigitalOceanIntegrationTest {
     assertNotNull(fw);
     log.info(fw.toString());
   }
-  
+
   @Test
   public void testUpdateFirewallInfo() throws DigitalOceanException, RequestUnsuccessfulException {
     Firewall firewall = apiClient.getFirewallInfo(firewallIdForInfo);
-    
+
     firewall.setName("edited-firewall");
     Firewall fw = apiClient.updateFirewall(firewall);
-    
+
     assertNotNull(fw);
     assertEquals(fw.getName(), firewall.getName());
     assertEquals(fw.getId(), firewall.getId());
-    
+
     log.info(fw.toString());
   }
-  
+
   @Test
   public void testDeleteFirewall() throws DigitalOceanException, RequestUnsuccessfulException {
     Delete result = apiClient.deleteFirewall(firewallIdForInfo);
     assertNotNull(result);
   }
-  
+
   @Test
-  public void testGetAvailableFirewalls() throws DigitalOceanException, RequestUnsuccessfulException {
+  public void testGetAvailableFirewalls()
+      throws DigitalOceanException, RequestUnsuccessfulException {
     Firewalls firewalls = apiClient.getAvailableFirewalls(1, null);
-    
+
     assertNotNull(firewalls);
     assertFalse(firewalls.getFirewalls().isEmpty());
-    
+
     int i = 0;
     for (Firewall firewall : firewalls.getFirewalls()) {
       log.info(i++ + " -> " + firewall.toString());
     }
   }
-
 }

--- a/src/test/java/com/myjeeva/digitalocean/DigitalOceanMockTest.java
+++ b/src/test/java/com/myjeeva/digitalocean/DigitalOceanMockTest.java
@@ -2,10 +2,12 @@ package com.myjeeva.digitalocean;
 
 import static org.junit.Assert.assertEquals;
 
+import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
@@ -16,11 +18,6 @@ import org.apache.http.message.BasicHttpResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import com.myjeeva.digitalocean.impl.DigitalOceanClient;
-
-import mockit.Expectations;
-import mockit.Mocked;
 
 @SuppressWarnings("unused")
 @RunWith(JUnit4.class)
@@ -33,18 +30,23 @@ public class DigitalOceanMockTest {
 
     new Expectations() {
       {
-        defaultHttpClient.execute((HttpUriRequest)with(new Object() {
+        defaultHttpClient.execute(
+            (HttpUriRequest)
+                with(
+                    new Object() {
 
-          void validate(HttpUriRequest httpUriRequest) throws MalformedURLException,
-              URISyntaxException {
-            assertEquals(new URL("https://api.digitalocean.com/v2/droplets/1234/actions").toURI(),
-                httpUriRequest.getURI());
-          }
-        }));
-        
+                      void validate(HttpUriRequest httpUriRequest)
+                          throws MalformedURLException, URISyntaxException {
+                        assertEquals(
+                            new URL("https://api.digitalocean.com/v2/droplets/1234/actions")
+                                .toURI(),
+                            httpUriRequest.getURI());
+                      }
+                    }));
+
         BasicHttpResponse basicHttpResponse = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "");
-        basicHttpResponse
-            .setEntity(new StringEntity(
+        basicHttpResponse.setEntity(
+            new StringEntity(
                 "{   \"action\": {     \"id\": 36805022,     \"status\": \"in-progress\",     \"type\": \"snapshot\",     \"started_at\": \"2014-11-14T16:34:39Z\",     \"completed_at\": null,     \"resource_id\": 3164450,     \"resource_type\": \"droplet\",     \"region\": \"nyc3\"   } }",
                 ContentType.APPLICATION_JSON));
         basicHttpResponse.setHeader("RateLimit-Limit", "1200");

--- a/src/test/java/org/apache/http/impl/execchain/PublicHttpResponseProxy.java
+++ b/src/test/java/org/apache/http/impl/execchain/PublicHttpResponseProxy.java
@@ -1,36 +1,35 @@
 /**
  * The MIT License
- * 
- * Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
+ *
+ * <p>Copyright (c) 2013-2019 Jeevanandam M. (jeeva@myjeeva.com)
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all copies or
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package org.apache.http.impl.execchain;
 
 import org.apache.http.HttpResponse;
 
 /**
  * Reference: http://stackoverflow.com/a/28204232/1343356
- * 
+ *
  * @author Jeevanandam M. (jeeva@myjeeva.com)
  */
 public class PublicHttpResponseProxy extends HttpResponseProxy {
 
   public PublicHttpResponseProxy(HttpResponse original) {
-      super(original, null);
+    super(original, null);
   }
 }


### PR DESCRIPTION
In README it is stated that google java format is used on the project. This PR adds maven plugin that will check that source code is actually formatted with this tool and updates README on how to do it (I'm refering to maven wrapper from #98 - if you do not want to use maven wrapper I will remove reference to it from README)

It seems that eclipse google formatter config does not enforce as many rules as standalone up-to-date google java formatter tool. I apply it to in the same PR.