### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 jdk:
   - openjdk8
-  - openjdk11
-  - openjdk12
-  - openjdk13
+  #- openjdk11
+  #- openjdk12
+  #- openjdk13
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: java
-
 jdk:
-  - oraclejdk8
-  - oraclejdk7
-  #- openjdk6
+  - openjdk8
+  - openjdk11
+  - openjdk12
+  - openjdk13
 
 # whitelist
 branches:
   only:
     - master
     #- api-v1  # since v1 API becoe absolute
-
-matrix:
-  allow_failures:
-    - jdk: oraclejdk7


### PR DESCRIPTION
Current travis builds are failing due to not being able to install oraclejdk. This PR fixes it replacing it with openjdk of up-to-date versions.